### PR TITLE
[JENKINS-57973] Add logging

### DIFF
--- a/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/CliOptions.java
+++ b/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/CliOptions.java
@@ -7,7 +7,6 @@ import org.kohsuke.args4j.spi.BooleanOptionHandler;
 import org.kohsuke.args4j.spi.StringArrayOptionHandler;
 
 
-
 public class CliOptions {
     //path must include plugins.txt
     @Option(name = "-pluginTxtPath", usage = "Path to plugins.txt")
@@ -22,11 +21,14 @@ public class CliOptions {
     @Option(name = "-war", usage = "Path to Jenkins war file")
     public String jenkinsWarFile;
 
-    @Option(name = "-viewSecurityWarnings", usage = "Set to true to show specified plugins that have security warnings", handler = BooleanOptionHandler.class)
+    @Option(name = "-viewSecurityWarnings", usage = "Set to show specified plugins that have security warnings", handler = BooleanOptionHandler.class)
     public boolean showWarnings;
 
-    @Option(name = "-viewAllSecurityWarnings", usage = "Set to true to show all plugins that have security warnings", handler = BooleanOptionHandler.class)
+    @Option(name = "-viewAllSecurityWarnings", usage = "Set to show all plugins that have security warnings", handler = BooleanOptionHandler.class)
     public boolean showAllWarnings;
+
+    @Option(name="-verbose", usage = "Set to show detailed information about plugin downloads", handler = BooleanOptionHandler.class)
+    public boolean isOutputVerbose;
 
     public File getPluginTxt() {
         return pluginTxt;
@@ -40,9 +42,11 @@ public class CliOptions {
         return jenkinsWarFile;
     }
 
-
     public String[] getPlugins() {
-        return Arrays.copyOf(plugins, plugins.length);
+        if (plugins != null) {
+            return Arrays.copyOf(plugins, plugins.length);
+        }
+        return null;
     }
 
     public boolean isShowWarnings() {
@@ -51,5 +55,9 @@ public class CliOptions {
 
     public boolean isShowAllWarnings() {
         return showAllWarnings;
+    }
+
+    public boolean isOutputVerbose() {
+        return isOutputVerbose;
     }
 }

--- a/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/Main.java
+++ b/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/Main.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Scanner;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 

--- a/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/Main.java
+++ b/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/Main.java
@@ -11,12 +11,18 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 
 
 public class Main {
+    private static final Logger LOGGER = Logger.getLogger(Main.class.getName());
+
     public static void main(String[] args) throws IOException {
+
         List<Plugin> plugins = new ArrayList<>();
 
         CliOptions options = new CliOptions();

--- a/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/Main.java
+++ b/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/Main.java
@@ -21,7 +21,6 @@ public class Main {
     private static final Logger LOGGER = Logger.getLogger(Main.class.getName());
 
     public static void main(String[] args) throws IOException {
-
         List<Plugin> plugins = new ArrayList<>();
 
         CliOptions options = new CliOptions();
@@ -36,6 +35,7 @@ public class Main {
 
         Config cfg = new Config();
 
+        cfg.setOutputVerbose(options.isOutputVerbose());
         cfg.setShowWarnings(options.isShowWarnings());
         cfg.setShowAllWarnings(options.isShowAllWarnings());
 
@@ -46,53 +46,57 @@ public class Main {
             }
         }
 
+        StringBuilder optionInfo = new StringBuilder();
+
         if (options.getPluginTxt() == null) {
-            System.out.println("No file containing list of plugins to be downloaded entered. " +
-                    "Will use default of " + Settings.DEFAULT_PLUGIN_TXT);
+            optionInfo.append("No file containing list of plugins to be downloaded entered. " +
+                    "Will use default of " + Settings.DEFAULT_PLUGIN_TXT + "\n");
             cfg.setPluginTxt(Settings.DEFAULT_PLUGIN_TXT);
         }
         else {
-            System.out.println("File containing list of plugins to be downloaded: " + options.getPluginTxt());
+            optionInfo.append("File containing list of plugins to be downloaded: " + options.getPluginTxt() + "\n");
             cfg.setPluginTxt(options.getPluginTxt());
         }
 
 
         if (options.getPluginDir() == null) {
-            System.out.println("No directory to download plugins to entered. " +
-                    "Will use default of " + Settings.DEFAULT_PLUGIN_DIR);
+            optionInfo.append("No directory to download plugins to entered. " +
+                    "Will use default of " + Settings.DEFAULT_PLUGIN_DIR + "\n");
             cfg.setPluginDir(Settings.DEFAULT_PLUGIN_DIR);
         }
         else {
-            System.out.println("Plugin download location: " + options.getPluginDir());
+            optionInfo.append("Plugin download location: " + options.getPluginDir() + "\n");
             cfg.setPluginDir(options.getPluginDir());
         }
 
 
         if (options.getJenkinsWar() == null) {
-            System.out.println("No war entered. Will use default of " + Settings.DEFAULT_JENKINS_WAR);
+            optionInfo.append("No war entered. Will use default of " + Settings.DEFAULT_JENKINS_WAR + "\n");
             cfg.setJenkinsWar(Settings.DEFAULT_JENKINS_WAR);
         }
         else {
-            System.out.println("Will use war file: " + options.getJenkinsWar());
+            optionInfo.append("Will use war file: " + options.getJenkinsWar() + "\n");
             cfg.setJenkinsWar(options.getJenkinsWar());
         }
 
-        System.out.println("Show all security warnings: " + options.isShowAllWarnings());
+        optionInfo.append("Show all security warnings: " + options.isShowAllWarnings());
+
+        LOGGER.log(Level.INFO, optionInfo.toString());
 
         if (Files.exists(cfg.getPluginTxt().toPath())) {
             try {
                 Scanner scanner = new Scanner(cfg.getPluginTxt(), StandardCharsets.UTF_8.name());
-                System.out.println("Reading in plugins from " + cfg.getPluginTxt().toString() + "\n");
+                LOGGER.log(Level.INFO, "Reading in plugins from {0}", cfg.getPluginTxt().toString());
                 while (scanner.hasNextLine()) {
                     Plugin plugin = parsePluginLine(scanner.nextLine());
                     plugins.add(plugin);
                 }
             } catch (FileNotFoundException e) {
-                System.out.println("Unable to open " + cfg.getPluginTxt());
+                LOGGER.log(Level.WARNING, "Unable to open {0}", cfg.getPluginTxt());
             }
         }
         else {
-            System.out.println(cfg.getPluginTxt() + " file does not exist");
+            LOGGER.log(Level.WARNING, "{0} file does not exist", cfg.getPluginTxt());
         }
 
         cfg.setPlugins(plugins);

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Config.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Config.java
@@ -12,13 +12,14 @@ public class Config {
     private boolean showWarnings;
     private String jenkinsWar;
     private List<Plugin> plugins;
+    private boolean isOutputVerbose;
 
     public void setPluginDir(File pluginDir) {
         this.pluginDir = pluginDir;
     }
 
     public void setPluginTxt(File pluginTxt) {
-        this.pluginTxt =pluginTxt;
+        this.pluginTxt = pluginTxt;
     }
 
     public File getPluginDir() {
@@ -61,7 +62,16 @@ public class Config {
         return plugins;
     }
 
+    public boolean isOutputVerbose() {
+        return isOutputVerbose;
+    }
+
+    public void setOutputVerbose(boolean outputVerbose) {
+        isOutputVerbose = outputVerbose;
+    }
+
     public Config() {
         plugins = new ArrayList<>();
     }
+
 }


### PR DESCRIPTION
Changed user notifications from System.out.println to Java Util Logging as per https://issues.jenkins-ci.org/browse/JENKINS-57973 task. I must have accidentally created this branch off of the one I removed the file locks on.  This also seems to have had the side effect of printing a detailed message including the date, time, class, and method name every time a line is output. This makes the output less readable so I will need to figure out how to filter that info out.  