### PR TITLE
[JENKINS-57971] Fix parameter in getting started example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The plugin manager downloads plugins and their dependencies into a folder so tha
 #### Getting Started
 ```
 mvn clean install 
-java -jar plugin-management-cli/target/plugin-management-cli-1.0-SNAPSHOT-jar-with-dependencies.jar /file/path/jenkins.war -pluginTxtPath /file/path/plugins.txt -plugins delivery-pipeline-plugin:1.3.2 deployit-plugin
+java -jar plugin-management-cli/target/plugin-management-cli-1.0-SNAPSHOT-jar-with-dependencies.jar -war /file/path/jenkins.war -pluginTxtPath /file/path/plugins.txt -plugins delivery-pipeline-plugin:1.3.2 deployit-plugin
 ```
 
 #### CLI Options


### PR DESCRIPTION
Additional fixes for Documentation: https://issues.jenkins-ci.org/browse/JENKINS-57971

The current example for getting started is: 
java -jar plugin-management-cli/target/plugin-management-cli-1.0-SNAPSHOT-jar-with-dependencies.jar /file/path/jenkins.war -pluginTxtPath /file/path/plugins.txt -plugins delivery-pipeline-plugin:1.3.2 deployit-plugin

There is no -war parameter before the path to the war. 