### PR TITLE
[JENKINS-58199] Remove incrementals maven configuration

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,2 +1,0 @@
--Pconsume-incrementals
--Pmight-produce-incrementals


### PR DESCRIPTION
Project was configured to use and deploy incrementals but the repository format was not adjusted to this, which lead to an error when trying to release the alpha version.

https://issues.jenkins-ci.org/browse/JENKINS-58199