### PR TITLE
[JENKINS-58126] Skip blank lines and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ java -jar plugin-management-cli/target/plugin-management-cli-1.0-SNAPSHOT-jar-wi
 
 
 #### Plugin Input Format
-The expected format for plugins is `artifact ID:version:download url`
+The expected format for plugins is `artifact ID:version` or `artifact ID:url` or `artifact:version:url`
 
 Use plugin artifact ID, without -plugin extension. If a plugin cannot be downloaded, -plugin will be appended to the name and download will be retried. This is for cases in which plugins don't follow the rules about artifact ID (i.e. docker plugin).
 

--- a/plugin-management-library/pom.xml
+++ b/plugin-management-library/pom.xml
@@ -29,6 +29,11 @@
             <version>3.9</version>
         </dependency>
         <dependency>
+            <groupId>commons-validator</groupId>
+            <artifactId>commons-validator</artifactId>
+            <version>1.6</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>4.5.9</version>


### PR DESCRIPTION
So I tried to support the existing functionality, in which a user can enter a plugin like: artifact id: version: url. But if a url is entered, then the version is ignored.

Jira: https://issues.jenkins-ci.org/browse/JENKINS-58126 and https://issues.jenkins-ci.org/browse/JENKINS-58241
