### PR TITLE
[JENKINS-58364] Support default war for Windows, REF env var, remove …

### DIFF
--- a/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/CliOptions.java
+++ b/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/CliOptions.java
@@ -107,14 +107,18 @@ class CliOptions {
      *
      */
     private File getPluginDir() {
-        if (pluginDir == null) {
+        if (pluginDir != null) {
+            System.out.println("Plugin download location: " + pluginDir);
+            return pluginDir;
+        } else if (!StringUtils.isEmpty(System.getenv("REF")))  {
+            System.out.println("No directory to download plugins entered. " +
+                    "Will use location specified in REF environment variable: " + System.getenv("REF"));
+            return new File(System.getenv("REF"));
+        }
+
             System.out.println("No directory to download plugins entered. " +
                     "Will use default of " + Settings.DEFAULT_PLUGIN_DIR);
             return Settings.DEFAULT_PLUGIN_DIR;
-        } else {
-            System.out.println("Plugin download location: " + pluginDir);
-            return pluginDir;
-        }
     }
 
     /**

--- a/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/CliOptions.java
+++ b/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/CliOptions.java
@@ -93,13 +93,11 @@ class CliOptions {
 
     private File getPluginTxt() {
         if (pluginTxt == null) {
-            System.out.println("No file containing list of plugins to be downloaded entered. Will use default of " +
-                    Settings.DEFAULT_PLUGIN_TXT);
-            return Settings.DEFAULT_PLUGIN_TXT;
+            System.out.println("No file containing list of plugins to be downloaded entered.");
         } else {
             System.out.println("File containing list of plugins to be downloaded: " + pluginTxt);
-            return pluginTxt;
         }
+        return pluginTxt;
     }
 
     /**
@@ -110,12 +108,11 @@ class CliOptions {
         if (pluginDir != null) {
             System.out.println("Plugin download location: " + pluginDir);
             return pluginDir;
-        } else if (!StringUtils.isEmpty(System.getenv("REF")))  {
+        } else if (!StringUtils.isEmpty(System.getenv("PLUGIN_DIR")))  {
             System.out.println("No directory to download plugins entered. " +
-                    "Will use location specified in REF environment variable: " + System.getenv("REF"));
-            return new File(System.getenv("REF"));
+                    "Will use location specified in PLUGIN_DIR environment variable: " + System.getenv("PLUGIN_DIR"));
+            return new File(System.getenv("PLUGIN_DIR"));
         }
-
             System.out.println("No directory to download plugins entered. " +
                     "Will use default of " + Settings.DEFAULT_PLUGIN_DIR);
             return Settings.DEFAULT_PLUGIN_DIR;
@@ -149,6 +146,9 @@ class CliOptions {
                 .collect(toList());
 
         File pluginFileLocation = getPluginTxt();
+        if (pluginFileLocation == null) {
+            return mappedPlugins;
+        }
         if (Files.exists(pluginFileLocation.toPath())) {
             try (BufferedReader bufferedReader = Files.newBufferedReader(pluginFileLocation.toPath(),
                     StandardCharsets.UTF_8))
@@ -165,7 +165,7 @@ class CliOptions {
                 System.out.println("Unable to open " + pluginFileLocation);
             }
         } else {
-            System.out.println(pluginFileLocation + " file does not exist");
+            System.out.println(pluginFileLocation + " File does not exist");
         }
 
         return mappedPlugins;

--- a/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/CliOptions.java
+++ b/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/CliOptions.java
@@ -114,8 +114,8 @@ class CliOptions {
             return new File(System.getenv("PLUGIN_DIR"));
         }
             System.out.println("No directory to download plugins entered. " +
-                    "Will use default of " + Settings.DEFAULT_PLUGIN_DIR);
-            return Settings.DEFAULT_PLUGIN_DIR;
+                    "Will use default of " + Settings.DEFAULT_PLUGIN_DIR_LOCATION);
+            return new File(Settings.DEFAULT_PLUGIN_DIR_LOCATION);
     }
 
     /**

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Settings.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Settings.java
@@ -1,12 +1,10 @@
 package io.jenkins.tools.pluginmanager.config;
 
-import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 
 public class Settings {
-
-    public static final File DEFAULT_PLUGIN_DIR;
+    public static final String DEFAULT_PLUGIN_DIR_LOCATION;
     public static final String DEFAULT_WAR;
     public static final URL DEFAULT_UPDATE_CENTER;
     public static final String DEFAULT_UPDATE_CENTER_LOCATION = "https://updates.jenkins.io";
@@ -26,11 +24,11 @@ public class Settings {
 
         if (System.getProperty("os.name").toLowerCase().contains("windows")) {
             DEFAULT_WAR = "C:\\ProgramData\\Jenkins\\jenkins.war";
-            DEFAULT_PLUGIN_DIR = new File("C:\\ProgramData\\Jenkins\\Reference\\Plugins");
+            DEFAULT_PLUGIN_DIR_LOCATION = "C:\\ProgramData\\Jenkins\\Reference\\Plugins";
         }
         else {
             DEFAULT_WAR = "/usr/share/jenkins/jenkins.war";
-            DEFAULT_PLUGIN_DIR = new File("/usr/share/jenkins/ref/plugins");
+            DEFAULT_PLUGIN_DIR_LOCATION = "/usr/share/jenkins/ref/plugins";
         }
     }
 }

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Settings.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Settings.java
@@ -7,8 +7,8 @@ import java.net.URL;
 public class Settings {
 
     public static final File DEFAULT_PLUGIN_TXT = new File(System.getProperty("user.dir") + File.separator + "plugins.txt");
-    public static final File DEFAULT_PLUGIN_DIR = new File(System.getProperty("user.dir") + File.separator + "plugins");
-    public static final String DEFAULT_WAR = "/usr/share/jenkins/jenkins.war";
+    public static final File DEFAULT_PLUGIN_DIR = new File("/usr/share/jenkins/ref/plugins");
+    public static final String DEFAULT_WAR;
     public static final URL DEFAULT_UPDATE_CENTER;
     public static final String DEFAULT_UPDATE_CENTER_LOCATION = "https://updates.jenkins.io";
     public static final URL DEFAULT_EXPERIMENTAL_UPDATE_CENTER;
@@ -24,5 +24,13 @@ public class Settings {
         } catch (MalformedURLException e) {
             throw new RuntimeException(e);
         }
+
+        if (System.getProperty("os.name").toLowerCase().contains("windows")) {
+            DEFAULT_WAR = "C:\\ProgramData\\Jenkins\\jenkins.war";
+        }
+        else {
+            DEFAULT_WAR = "/usr/share/jenkins/jenkins.war";
+        }
+
     }
 }

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Settings.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Settings.java
@@ -6,8 +6,7 @@ import java.net.URL;
 
 public class Settings {
 
-    public static final File DEFAULT_PLUGIN_TXT = new File(System.getProperty("user.dir") + File.separator + "plugins.txt");
-    public static final File DEFAULT_PLUGIN_DIR = new File("/usr/share/jenkins/ref/plugins");
+    public static final File DEFAULT_PLUGIN_DIR;
     public static final String DEFAULT_WAR;
     public static final URL DEFAULT_UPDATE_CENTER;
     public static final String DEFAULT_UPDATE_CENTER_LOCATION = "https://updates.jenkins.io";
@@ -27,10 +26,11 @@ public class Settings {
 
         if (System.getProperty("os.name").toLowerCase().contains("windows")) {
             DEFAULT_WAR = "C:\\ProgramData\\Jenkins\\jenkins.war";
+            DEFAULT_PLUGIN_DIR = new File("C:\\ProgramData\\Jenkins\\Reference\\Plugins");
         }
         else {
             DEFAULT_WAR = "/usr/share/jenkins/jenkins.war";
+            DEFAULT_PLUGIN_DIR = new File("/usr/share/jenkins/ref/plugins");
         }
-
     }
 }

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -7,14 +7,11 @@ import java.io.FileFilter;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -168,10 +165,7 @@ public class PluginManager {
     public void outputFailedPlugins() {
         if (failedPlugins.size() > 0) {
             System.out.println("Some plugins failed to download: ");
-            for (Plugin plugin : failedPlugins) {
-                String failedPluginName = plugin.getName();
-                System.out.println(failedPluginName);
-            }
+            failedPlugins.stream().map(Plugin::getName).forEach(System.out::println);
         }
         System.exit(1);
     }

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -105,7 +105,7 @@ public class PluginManager {
 
         downloadPlugins(plugins);
 
-        writeFailedPluginsToFile();
+        outputFailedPlugins();
 
         //clean up locks
 
@@ -162,29 +162,19 @@ public class PluginManager {
                 System.out.println(
                         "Unable to check if version specific update center for Jenkins version " + jenkinsVersion);
             }
-
         }
-
     }
 
-
-    public void writeFailedPluginsToFile() {
-        try (
-          FileOutputStream fileOutputStream = new FileOutputStream("failedplugins.txt");
-          Writer fstream = new OutputStreamWriter(fileOutputStream, StandardCharsets.UTF_8)
-        ) {
-                if (failedPlugins.size() > 0) {
-                    System.out.println("Some plugins failed to download: ");
-                    for (Plugin plugin : failedPlugins) {
-                        String failedPluginName = plugin.getName();
-                        System.out.println(failedPluginName);
-                        fstream.write(failedPluginName + "\n");
-                    }
-                }
-            } catch (IOException e) {
-                e.printStackTrace();
+    public void outputFailedPlugins() {
+        if (failedPlugins.size() > 0) {
+            System.out.println("Some plugins failed to download: ");
+            for (Plugin plugin : failedPlugins) {
+                String failedPluginName = plugin.getName();
+                System.out.println(failedPluginName);
             }
         }
+        System.exit(1);
+    }
 
     public void downloadPlugins(List<Plugin> plugins) {
         for (Plugin plugin : plugins) {
@@ -295,7 +285,7 @@ public class PluginManager {
         String pluginDownloadUrl = getPluginDownloadUrl(plugin);
         boolean successfulDownload = downloadToFile(pluginDownloadUrl, plugin);
         if (!successfulDownload) {
-            //some plugin don't follow the rules about artifact ID, i.e. docker-plugin
+            //some plugins don't follow the rules about artifact ID, i.e. docker-plugin
             String newPluginName = plugin.getName() + "-plugin";
             plugin.setName(newPluginName);
             pluginDownloadUrl = getPluginDownloadUrl(plugin);

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -1,5 +1,6 @@
 package io.jenkins.tools.pluginmanager.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.util.VersionNumber;
 import io.jenkins.tools.pluginmanager.config.Config;
 import java.io.File;
@@ -43,6 +44,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.json.JSONArray;
 import org.json.JSONObject;
+
 
 public class PluginManager {
     private List<Plugin> plugins;
@@ -101,7 +103,7 @@ public class PluginManager {
     }
 
     /**
-     * Gets the security warnings for plugins from the update center json and creates a list of all teh security
+     * Gets the security warnings for plugins from the update center json and creates a list of all the security
      * warnings
      */
     public void getSecurityWarnings() {
@@ -164,6 +166,7 @@ public class PluginManager {
     /**
      * Prints out plugins that failed to download. Exits with status of 1 if any plugins failed to download.
      */
+    @SuppressFBWarnings("DM_EXIT")
     public void outputFailedPlugins() {
         if (failedPlugins.size() > 0) {
             System.out.println("Some plugins failed to download: ");

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
@@ -90,7 +90,6 @@ public class PluginManagerTest {
 
     @Test
     public void getPluginVersionTest() {
-
         URL jpiURL = this.getClass().getResource("/delivery-pipeline-plugin.jpi");
         File testJpi = new File(jpiURL.getFile());
 
@@ -115,13 +114,11 @@ public class PluginManagerTest {
         URL deliveryPipelineJpi = this.getClass().getResource("/delivery-pipeline-plugin.jpi");
         File deliveryPipelineFile = new File(deliveryPipelineJpi.getFile());
 
-
         URL githubJpi = this.getClass().getResource("/github-branch-source.jpi");
         File githubFile = new File(githubJpi.getFile());
 
         FileUtils.copyFile(deliveryPipelineFile, tmp1);
         FileUtils.copyFile(githubFile, tmp2);
-
 
         expectedPlugins.add(FilenameUtils.getBaseName(tmp1.getName()));
         expectedPlugins.add(FilenameUtils.getBaseName(tmp2.getName()));


### PR DESCRIPTION
…failed plugin file

Goal of this PR is to try to fix the last outstanding issues that are blocking this tool from replacing the Docker install-plugins.sh script.

Fixes: 
https://issues.jenkins-ci.org/browse/JENKINS-58364
https://issues.jenkins-ci.org/browse/JENKINS-58389
https://issues.jenkins-ci.org/browse/JENKINS-58216

Question - will the default plugin directory also need to be different for Windows machines similar to the default war? 
