### PR TITLE
[JENKINS-58452] Get plugin dependencies from plugin-versions.json

### DIFF
--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Settings.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Settings.java
@@ -12,6 +12,7 @@ public class Settings {
     public static final String DEFAULT_EXPERIMENTAL_UPDATE_CENTER_LOCATION = "https://updates.jenkins.io/experimental";
     public static final URL DEFAULT_INCREMENTALS_REPO_MIRROR;
     public static final String DEFAULT_INCREMENTALS_REPO_MIRROR_LOCATION = "https://repo.jenkins-ci.org/incrementals";
+    public static final String DEFAULT_PLUGIN_INFO_LOCATION = "https://updates.jenkins.io/current/plugin-versions.json";
 
     static {
         try {
@@ -25,8 +26,7 @@ public class Settings {
         if (System.getProperty("os.name").toLowerCase().contains("windows")) {
             DEFAULT_WAR = "C:\\ProgramData\\Jenkins\\jenkins.war";
             DEFAULT_PLUGIN_DIR_LOCATION = "C:\\ProgramData\\Jenkins\\Reference\\Plugins";
-        }
-        else {
+        } else {
             DEFAULT_WAR = "/usr/share/jenkins/jenkins.war";
             DEFAULT_PLUGIN_DIR_LOCATION = "/usr/share/jenkins/ref/plugins";
         }

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -247,13 +247,9 @@ public class PluginManager {
             // assumes that plugin info will be sorted by version
             if (StringUtils.isEmpty(jenkinsUcLatest)) {
                 specificVersionInfo = (JSONObject) pluginInfo.get((String) versions.get(versions.size()-1));
-                System.out.println("version" + versions.get(versions.size()-1));
             } else {
-                System.out.println("no jenkins uc latest");
                 for (int i = versions.size() - 1; i >= 0; i--) {
-                    System.out.println("version" + versions.get(i));
                     specificVersionInfo = (JSONObject) pluginInfo.get((String) versions.get(i));
-                    System.out.println("required core " + specificVersionInfo.getString("requiredCore"));
                     if (new VersionNumber(specificVersionInfo.getString("requiredCore")).compareTo(jenkinsVersion)  <= 0) {
                         break;
                     }

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
@@ -54,7 +54,7 @@ public class PluginManagerTest {
     @Test
     public void checkVersionSpecificUpdateCenterTest() throws Exception {
         //Test where version specific update center exists
-        pm.setJenkinsVersion("2.176");
+        pm.setJenkinsVersion(new VersionNumber("2.176"));
 
         PowerMockito.mockStatic(HttpClients.class);
         CloseableHttpClient httpclient = Mockito.mock(CloseableHttpClient.class);
@@ -72,7 +72,7 @@ public class PluginManagerTest {
         int statusCode = HttpStatus.SC_OK;
         Mockito.when(statusLine.getStatusCode()).thenReturn(statusCode);
 
-        pm.checkVersionSpecificUpdateCenter();
+        pm.checkAndSetVersionSpecificUpdateCenter();
 
         String expected = cfg.getJenkinsUc().toString() + "/" + pm.getJenkinsVersion();
         Assert.assertEquals(expected, pm.getJenkinsUCLatest());
@@ -81,7 +81,7 @@ public class PluginManagerTest {
         statusCode = HttpStatus.SC_BAD_REQUEST;
         Mockito.when(statusLine.getStatusCode()).thenReturn(statusCode);
 
-        pm.checkVersionSpecificUpdateCenter();
+        pm.checkAndSetVersionSpecificUpdateCenter();
 
         expected = "";
         Assert.assertEquals(expected, pm.getJenkinsUCLatest());
@@ -241,7 +241,7 @@ public class PluginManagerTest {
                 .withJenkinsWar(testWar.toString())
                 .build();
         PluginManager pluginManager = new PluginManager(config);
-        Assert.assertEquals("2.164.1", pluginManager.getJenkinsVersionFromWar());
+        Assert.assertEquals(new VersionNumber("2.164.1").compareTo(pluginManager.getJenkinsVersionFromWar()), 0);
     }
 
 


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-58452

This is still a little jenky for the following reason: 

If a user requests a plugin of the latest version, because we're now getting the plugin's dependency from plugin-versions.json, which lists the dependencies specific to each version, we now have to figure out which version is the "latest."  Unfortunately, this is not as easy as just getting the latest plugin version because in the getPluginDownloadUrl() method, we also determine the "latest" download URL based off of if there's a Jenkins version-specific update center.  

As is, this code should be consistent with how the install-plugins bash script was previously working, although it is possible for a user to download a plugin version that is inconsistent with their version of Jenkins.  I had already created a ticket for this: https://issues.jenkins-ci.org/browse/JENKINS-58308 and I think if this looks ok I will fix this in another PR. 