### PR TITLE
[JENKINS-58452] Fix for getting plugin dependencies from UC json

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The version and  download url are optional. By default, the latest version of th
 
 The following custom version specifiers can also be used: 
 
-* `latest` - downloads the latest version from the main update center [https://updates.jenkins.io](https://updates.jenkins.io)
+* `latest` - downloads the latest version from a version specific update center if one exists for the version in the Jenkins war file. If no version specific update center exists, will use the main update center [https://updates.jenkins.io](https://updates.jenkins.io)
 * `experimental` - downloads the latest version from the [experimental update center](https://jenkins.io/doc/developer/publishing/releasing-experimental-updates/), which offers Alpha and Beta versions of plugins. Default value: [https://updates.jenkins.io/experimental](https://updates.jenkins.io/experimental)
 * `incrementals;org.jenkins-ci.plugins.workflow;2.19-rc289.d09828a05a74` - downloads the plugin from the [incrementals repo](https://jenkins.io/blog/2018/05/15/incremental-deployment/). For this option you need to specify groupId of the plugin. Note that this value may change between plugin versions without notice. More information on incrementals and their use for Docker images can be found [here](https://github.com/jenkinsci/incrementals-tools#updating-versions-for-jenkins-docker-images).  
 

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/Plugin.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/Plugin.java
@@ -1,15 +1,15 @@
 package io.jenkins.tools.pluginmanager.impl;
 
 import hudson.util.VersionNumber;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.jar.JarFile;
 
 public class Plugin {
     private String name;
     private VersionNumber version;
     private String url;
-    private JarFile jarFile;
+    private File file;
     private boolean isPluginOptional;
     private List<Plugin> dependencies;
     private List<Plugin> dependents;
@@ -41,8 +41,8 @@ public class Plugin {
         this.url = url;
     }
 
-    public void setJarFile(JarFile jarFile) {
-        this.jarFile = jarFile;
+    public void setFile(File file) {
+        this.file = file;
     }
 
     public void setPluginOptional(boolean isPluginOptional) {
@@ -69,8 +69,8 @@ public class Plugin {
         return isPluginOptional;
     }
 
-    public JarFile getJarFile() {
-        return jarFile;
+    public File getFile() {
+        return file;
     }
 
     public void setDependencies(List<Plugin> dependencies) {

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
@@ -72,7 +72,7 @@ public class PluginManagerTest {
         int statusCode = HttpStatus.SC_OK;
         Mockito.when(statusLine.getStatusCode()).thenReturn(statusCode);
 
-        pm.checkAndSetVersionSpecificUpdateCenter();
+        pm.checkAndSetLatestUpdateCenter();
 
         String expected = cfg.getJenkinsUc().toString() + "/" + pm.getJenkinsVersion();
         Assert.assertEquals(expected, pm.getJenkinsUCLatest());
@@ -81,9 +81,9 @@ public class PluginManagerTest {
         statusCode = HttpStatus.SC_BAD_REQUEST;
         Mockito.when(statusLine.getStatusCode()).thenReturn(statusCode);
 
-        pm.checkAndSetVersionSpecificUpdateCenter();
+        pm.checkAndSetLatestUpdateCenter();
 
-        expected = "";
+        expected = cfg.getJenkinsUc().toString();
         Assert.assertEquals(expected, pm.getJenkinsUCLatest());
     }
 
@@ -212,12 +212,12 @@ public class PluginManagerTest {
         Assert.assertEquals(experimentalUrl, pm.getPluginDownloadUrl(plugin));
 
         VersionNumber incrementalVersion =
-                new VersionNumber("incrementals;org.jenkins-ci.plugins.workflow;2.19-rc289.d09828a05a74");
+                new VersionNumber("incrementals;org.jenkins-ci.plugins.pluginName;2.19-rc289.d09828a05a74");
 
         plugin.setVersion(incrementalVersion);
 
         String incrementalUrl = cfg.getJenkinsIncrementalsRepoMirror() +
-                "/org/jenkins-ci/plugins/workflow/pluginName/2.19-rc289.d09828a05a74/pluginName-2.19-rc289.d09828a05a74.hpi";
+                "/org/jenkins-ci/plugins/pluginName/2.19-rc289.d09828a05a74/pluginName-2.19-rc289.d09828a05a74.hpi";
 
         Assert.assertEquals(incrementalUrl, pm.getPluginDownloadUrl(plugin));
 


### PR DESCRIPTION
I came to the conclusion that getting the dependencies from multiple json sources seemed unavoidable if the dependencies were to be accurate.  For incremental plugins and plugins that were to be downloaded from a url, I parsed dependencies from the manifest after the plugin was downloaded. There didn't seem to be a json file that had all the dependencies listed for each incremental version and if the plugin is requested from a url, you would have to figure out the plugin version by parsing the url and get the dependencies from the update center using this version, but that may not even work if someone requests for a plugin to be downloaded from a non-Jenkins url. 

This PR *should* fix @slide's issue  and also includes a fix for an issue with the incrementals url. 

https://issues.jenkins-ci.org/browse/JENKINS-58452