### PR TITLE
[JENKINS-58199] Fix pom issue

### DIFF
--- a/plugin-management-cli/pom.xml
+++ b/plugin-management-cli/pom.xml
@@ -56,9 +56,4 @@
         </plugins>
     </build>
 
-
-
-  <scm>
-    <tag>plugin-management-library-0.1-alpha-4</tag>
-  </scm>
 </project>

--- a/plugin-management-library/pom.xml
+++ b/plugin-management-library/pom.xml
@@ -46,7 +46,4 @@
     </dependencies>
 
 
-  <scm>
-    <tag>plugin-management-library-0.1-alpha-4</tag>
-  </scm>
 </project>


### PR DESCRIPTION
Unable to do the release because of error:

Unable to checkout from SCM
[ERROR] Provider message:
[ERROR] The git-clone command failed.
[ERROR] Command output:
[ERROR] Cloning into '/Users/natashastopa/Jenkins/PluginManagement/target/checkout'...
[ERROR] fatal: Remote branch jenkins-plugin-management-parent-pom-0.1-alpha-5 not found in upstream origin