### PR TITLE
[JENKINS-58539] Exit with 0 if no failed plugins

### DIFF
--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -183,8 +183,9 @@ public class PluginManager {
         if (failedPlugins.size() > 0) {
             System.out.println("Some plugins failed to download: ");
             failedPlugins.stream().map(p -> p.getOriginalName() + " or " + p.getName()).forEach(System.out::println);
+            System.exit(1);
         }
-        System.exit(1);
+        System.exit(0);
     }
 
     /**


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-58539

Not entirely sure if I really need the explicit System.exit(0) it there were no errors.