### PR TITLE
[JENKINS-58147] Update yaml support to include groupId for incrementals

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,4 +92,4 @@ The plugin manager tries to use update center data to get the latest information
 
 For plugins listed in a .txt file, each plugin must be listed on a new line. Comments beginning with `#` will be filtered out.
 
-Support for downloading plugins from maven is not yet supported, but is a feature that is planned to be added in the future [JENKINS-58217](https://issues.jenkins-ci.org/browse/JENKINS-58217)
+Support for downloading plugins from maven is not currently supported. [JENKINS-58217](https://issues.jenkins-ci.org/browse/JENKINS-58217)

--- a/README.md
+++ b/README.md
@@ -45,20 +45,29 @@ Plugins can also be entered in a Jenkins yaml file with the following format:
 jenkins:
   ...
 plugins:
-  - artifactId: plugin1_artifactId
-    source: 
-      version: plugin1_version
-      url: plugin1_url
-  - artifactId: plugin2_artifactId
+- artifactId: git
     source:
-      version: plugin2_version
-  - artifactId: plugin3_artifactId
+      version: latest
+  - artifactId: job-import-plugin
+    source:
+      version: 2.1
+  - artifactId: docker
+  - artifactId: cloudbees-bitbucket-branch-source
+    source:
+      version: 2.4.4
+  - artifactId: script-security
+    source:
+      url: http://ftp-chi.osuosl.org/pub/jenkins/plugins/script-security/1.56/script-security.hpi
+  - artifactId: workflow-step-api
+    groupId: org.jenkins-ci.plugins.workflow
+    source:
+      version: 2.19-rc289.d09828a05a74
   ...
 tool:
   ...
 ```
 
-Any root object other than `plugins` will be ignored. As with the plugins.txt file, version and url are optional, and if no version is entered, the latest version is the default.
+Any root object other than `plugins` will be ignored by the plugin installation manager tool. As with the plugins.txt file, version and url are optional, and if no version is entered, the latest version is the default. If a groupId is entered, the tool will try to download the plugin from the incrementals repository.
 
 
 #### Examples
@@ -80,4 +89,7 @@ java -jar plugin-management-cli/target/plugin-management-tool.jar -p "workflow-s
 
 #### Other Information
 The plugin manager tries to use update center data to get the latest information about a plugin's dependencies. If this information is unavailable, it will use the dependency information from the downloaded plugin's MANIFEST.MF file.
+
 For plugins listed in a .txt file, each plugin must be listed on a new line. Comments beginning with `#` will be filtered out.
+
+Support for downloading plugins from maven is not yet supported, but is a feature that is planned to be added in the future [JENKINS-58217](https://issues.jenkins-ci.org/browse/JENKINS-58217)

--- a/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/PluginInputFormatException.java
+++ b/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/PluginInputFormatException.java
@@ -1,0 +1,12 @@
+package src.main.java.io.jenkins.tools.pluginmanager.cli;
+
+public class PluginInputFormatException extends RuntimeException {
+
+    public PluginInputFormatException(String message) {
+        super(message);
+    }
+
+    public PluginInputFormatException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/PluginParser.java
+++ b/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/PluginParser.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.validator.routines.UrlValidator;
 import org.yaml.snakeyaml.Yaml;
+import src.main.java.io.jenkins.tools.pluginmanager.cli.PluginInputFormatException;
 
 import static java.util.stream.Collectors.toList;
 
@@ -76,21 +77,21 @@ public class PluginParser {
                     Object nameObject = pluginInfo.get("artifactId");
                     String name = nameObject == null ? null : nameObject.toString();
                     if (StringUtils.isEmpty(name)) {
-                        System.out.println("artifactId is required, skipping...");
-                        continue;
+                        throw new PluginInputFormatException("ArtifactId is required");
                     }
                     Object groupIdObject = pluginInfo.get("groupId");
                     String groupId = groupIdObject == null ? null : groupIdObject.toString();
                     Map pluginSource = (Map) pluginInfo.get("source");
                     String incrementalsVersion = null;
                     Plugin plugin;
-                    if (pluginSource == null) {
+                    if (pluginSource == null && !StringUtils.isEmpty(groupId)) {
+                        throw new PluginInputFormatException("Version must be input for " + name);
+                    } else if (pluginSource == null) {
                         plugin = new Plugin(name, "latest", null, null);
                     } else {
                         Object versionObject = pluginSource.get("version");
                         if (!StringUtils.isEmpty(groupId) && versionObject == null) {
-                            System.out.println("Version must be input for " + name + ". Skipping...");
-                            continue;
+                            throw new PluginInputFormatException("Version must be input for " + name);
                         }
                         String version = versionObject == null ? "latest" : versionObject.toString();
                         Object urlObject = pluginSource.get("url");

--- a/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/PluginParser.java
+++ b/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/PluginParser.java
@@ -1,5 +1,6 @@
 package io.jenkins.tools.pluginmanager.cli;
 
+import io.jenkins.tools.pluginmanager.cli.PluginInputFormatException;
 import io.jenkins.tools.pluginmanager.impl.Plugin;
 import java.io.BufferedReader;
 import java.io.File;
@@ -15,7 +16,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.yaml.snakeyaml.Yaml;
-import io.jenkins.tools.pluginmanager.cli.PluginInputFormatException;
+
 
 import static java.util.stream.Collectors.toList;
 
@@ -156,7 +157,6 @@ public class PluginParser {
         }
 
         if (pluginInfo.length >= 3) {
-            pluginVersion = pluginInfo[1];
             if (isURL(pluginInfo[2])) {
                 pluginUrl = pluginInfo[2];
             } else {

--- a/plugin-management-cli/src/test/java/io/jenkins/tools/pluginmanager/cli/CliOptionsTest.java
+++ b/plugin-management-cli/src/test/java/io/jenkins/tools/pluginmanager/cli/CliOptionsTest.java
@@ -54,20 +54,20 @@ public class CliOptionsTest {
         //corresponds to plugins in plugin.txt
         txtRequestedPlugins = new ArrayList<>();
         txtRequestedPlugins.add(new Plugin("google-api-client-plugin",
-                "latest", "https://updates.jenkins.io/latest/google-api-client-plugin.hpi"));
-        txtRequestedPlugins.add(new Plugin("git", "latest", null));
-        txtRequestedPlugins.add(new Plugin("job-import-plugin", "2.1", null));
-        txtRequestedPlugins.add(new Plugin("docker", "latest", null));
-        txtRequestedPlugins.add(new Plugin("cloudbees-bitbucket-branch-source", "2.4.4", null));
+                "latest", "https://updates.jenkins.io/latest/google-api-client-plugin.hpi", null));
+        txtRequestedPlugins.add(new Plugin("git", "latest", null, null));
+        txtRequestedPlugins.add(new Plugin("job-import-plugin", "2.1", null, null));
+        txtRequestedPlugins.add(new Plugin("docker", "latest", null, null));
+        txtRequestedPlugins.add(new Plugin("cloudbees-bitbucket-branch-source", "2.4.4", null, null));
         txtRequestedPlugins.add(new Plugin("script-security", "latest",
-                "http://ftp-chi.osuosl.org/pub/jenkins/plugins/script-security/1.56/script-security.hpi"));
+                "http://ftp-chi.osuosl.org/pub/jenkins/plugins/script-security/1.56/script-security.hpi", null));
         txtRequestedPlugins.add(new Plugin("workflow-step-api",
-                "incrementals;org.jenkins-ci.plugins.workflow;2.19-rc289.d09828a05a74", null));
-        txtRequestedPlugins.add(new Plugin("matrix-project", "latest", null));
-        txtRequestedPlugins.add(new Plugin("junit", "experimental", null));
+                "2.19-rc289.d09828a05a74", null, "org.jenkins-ci.plugins.workflow"));
+        txtRequestedPlugins.add(new Plugin("matrix-project", "latest", null, null));
+        txtRequestedPlugins.add(new Plugin("junit", "experimental", null, null));
         txtRequestedPlugins.add(new Plugin("credentials", "2.2.0",
-                "http://ftp-chi.osuosl.org/pub/jenkins/plugins/credentials/2.2.0/credentials.hpi"));
-        txtRequestedPlugins.add(new Plugin("blueocean", "latest", null));
+                "http://ftp-chi.osuosl.org/pub/jenkins/plugins/credentials/2.2.0/credentials.hpi", null));
+        txtRequestedPlugins.add(new Plugin("blueocean", "latest", null, null));
 
         System.setOut(new PrintStream(outContent));
     }
@@ -111,7 +111,7 @@ public class CliOptionsTest {
                 "display-url-api::https://updates.jenkins.io/download/plugins/display-url-api/1.0/display-url-api.hpi");
 
         Plugin displayUrlPlugin = new Plugin("display-url-api", "latest",
-                "https://updates.jenkins.io/download/plugins/display-url-api/1.0/display-url-api.hpi");
+                "https://updates.jenkins.io/download/plugins/display-url-api/1.0/display-url-api.hpi", null);
 
         Config cfg = options.setup();
 
@@ -132,9 +132,9 @@ public class CliOptionsTest {
                 "--plugins", "ssh-slaves:1.10 mailer cobertura:experimental");
 
         List<Plugin> requestedPlugins = new ArrayList<>(txtRequestedPlugins);
-        requestedPlugins.add(new Plugin("ssh-slaves", "1.10", null));
-        requestedPlugins.add(new Plugin("mailer", "latest", null));
-        requestedPlugins.add(new Plugin("cobertura", "experimental", null));
+        requestedPlugins.add(new Plugin("ssh-slaves", "1.10", null, null));
+        requestedPlugins.add(new Plugin("mailer", "latest", null, null));
+        requestedPlugins.add(new Plugin("cobertura", "experimental", null, null));
 
         Config cfg = options.setup();
 

--- a/plugin-management-cli/src/test/java/io/jenkins/tools/pluginmanager/cli/PluginParserTest.java
+++ b/plugin-management-cli/src/test/java/io/jenkins/tools/pluginmanager/cli/PluginParserTest.java
@@ -30,21 +30,21 @@ public class PluginParserTest {
         pluginParser = new PluginParser();
 
         expectedPluginInfo = new ArrayList<>();
-        expectedPluginInfo.add(new Plugin("git", "latest", null).toString());
-        expectedPluginInfo.add(new Plugin("job-import-plugin", "2.1", null).toString());
-        expectedPluginInfo.add(new Plugin("docker", "latest", null).toString());
-        expectedPluginInfo.add(new Plugin("cloudbees-bitbucket-branch-source", "2.4.4", null).toString());
+        expectedPluginInfo.add(new Plugin("git", "latest", null, null).toString());
+        expectedPluginInfo.add(new Plugin("job-import-plugin", "2.1", null, null).toString());
+        expectedPluginInfo.add(new Plugin("docker", "latest", null, null).toString());
+        expectedPluginInfo.add(new Plugin("cloudbees-bitbucket-branch-source", "2.4.4", null, null).toString());
         expectedPluginInfo.add(new Plugin("script-security", "latest",
-                "http://ftp-chi.osuosl.org/pub/jenkins/plugins/script-security/1.56/script-security.hpi").toString());
+                "http://ftp-chi.osuosl.org/pub/jenkins/plugins/script-security/1.56/script-security.hpi", null).toString());
         expectedPluginInfo.add(new Plugin("workflow-step-api",
-                "incrementals;org.jenkins-ci.plugins.workflow;2.19-rc289.d09828a05a74", null).toString());
-        expectedPluginInfo.add(new Plugin("matrix-project", "latest", null).toString());
-        expectedPluginInfo.add(new Plugin("junit", "experimental", null).toString());
+                "2.19-rc289.d09828a05a74", null, "org.jenkins-ci.plugins.workflow").toString());
+        expectedPluginInfo.add(new Plugin("matrix-project", "latest", null, null).toString());
+        expectedPluginInfo.add(new Plugin("junit", "experimental", null, null).toString());
         expectedPluginInfo.add(new Plugin("credentials", "2.2.0",
-                "http://ftp-chi.osuosl.org/pub/jenkins/plugins/credentials/2.2.0/credentials.hpi").toString());
-        expectedPluginInfo.add(new Plugin("blueocean", "latest", null).toString());
+                "http://ftp-chi.osuosl.org/pub/jenkins/plugins/credentials/2.2.0/credentials.hpi", null).toString());
+        expectedPluginInfo.add(new Plugin("blueocean", "latest", null, null).toString());
         expectedPluginInfo.add(new Plugin("google-api-client-plugin", "latest",
-                "https://updates.jenkins.io/latest/google-api-client-plugin.hpi").toString());
+                "https://updates.jenkins.io/latest/google-api-client-plugin.hpi", null).toString());
 
         Collections.sort(expectedPluginInfo);
 

--- a/plugin-management-cli/src/test/java/io/jenkins/tools/pluginmanager/cli/PluginParserTest.java
+++ b/plugin-management-cli/src/test/java/io/jenkins/tools/pluginmanager/cli/PluginParserTest.java
@@ -1,5 +1,6 @@
 package io.jenkins.tools.pluginmanager.cli;
 
+import io.jenkins.tools.pluginmanager.cli.PluginInputFormatException;
 import io.jenkins.tools.pluginmanager.impl.Plugin;
 import java.io.File;
 import java.net.URISyntaxException;
@@ -13,7 +14,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import io.jenkins.tools.pluginmanager.cli.PluginInputFormatException;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;

--- a/plugin-management-cli/src/test/java/io/jenkins/tools/pluginmanager/cli/PluginParserTest.java
+++ b/plugin-management-cli/src/test/java/io/jenkins/tools/pluginmanager/cli/PluginParserTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import src.main.java.io.jenkins.tools.pluginmanager.cli.PluginInputFormatException;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -35,7 +36,8 @@ public class PluginParserTest {
         expectedPluginInfo.add(new Plugin("docker", "latest", null, null).toString());
         expectedPluginInfo.add(new Plugin("cloudbees-bitbucket-branch-source", "2.4.4", null, null).toString());
         expectedPluginInfo.add(new Plugin("script-security", "latest",
-                "http://ftp-chi.osuosl.org/pub/jenkins/plugins/script-security/1.56/script-security.hpi", null).toString());
+                "http://ftp-chi.osuosl.org/pub/jenkins/plugins/script-security/1.56/script-security.hpi", null)
+                .toString());
         expectedPluginInfo.add(new Plugin("workflow-step-api",
                 "2.19-rc289.d09828a05a74", null, "org.jenkins-ci.plugins.workflow").toString());
         expectedPluginInfo.add(new Plugin("matrix-project", "latest", null, null).toString());
@@ -119,6 +121,25 @@ public class PluginParserTest {
         assertEquals(expectedPluginInfo, pluginInfo);
     }
 
+    @Test(expected = PluginInputFormatException.class)
+    public void badFormatYamlNoArtifactIdTest() throws URISyntaxException {
+        File pluginYmlFile = new File(this.getClass().getResource("/badformat1.yaml").toURI());
+        List<Plugin> pluginsFromYamlFile = pluginParser.parsePluginYamlFile(pluginYmlFile);
+    }
+
+    @Test(expected = PluginInputFormatException.class)
+    public void badFormatYamlGroupIdNoVersion() throws URISyntaxException {
+        File pluginYmlFile = new File(this.getClass().getResource("/badformat2.yaml").toURI());
+        List<Plugin> pluginsFromYamlFile = pluginParser.parsePluginYamlFile(pluginYmlFile);
+    }
+
+    @Test(expected = PluginInputFormatException.class)
+    public void badFormatYamlGroupIdNoVersion2() throws URISyntaxException {
+        File pluginYmlFile = new File(this.getClass().getResource("/badformat3.yaml").toURI());
+        List<Plugin> pluginsFromYamlFile = pluginParser.parsePluginYamlFile(pluginYmlFile);
+    }
+
+    @Test
     public void fileExistsTest() throws URISyntaxException {
         assertEquals(false, pluginParser.fileExists(null));
 

--- a/plugin-management-cli/src/test/resources/badformat1.yaml
+++ b/plugin-management-cli/src/test/resources/badformat1.yaml
@@ -1,0 +1,7 @@
+plugins:
+  - artifactId: job-import-plugin
+    source:
+      version: 2.1
+  - artifactId:
+    source:
+      version: latest

--- a/plugin-management-cli/src/test/resources/badformat2.yaml
+++ b/plugin-management-cli/src/test/resources/badformat2.yaml
@@ -1,0 +1,15 @@
+jenkins:
+  systemMessage: "Testing"
+plugins:
+  - artifactId: git
+    source:
+      version: latest
+  - artifactId: workflow-step-api
+    groupId: org.jenkins-ci.plugins.workflow
+    source:
+      version:
+tool:
+  git:
+    installations:
+    - home: "git"
+      name: "Default"

--- a/plugin-management-cli/src/test/resources/badformat3.yaml
+++ b/plugin-management-cli/src/test/resources/badformat3.yaml
@@ -1,0 +1,13 @@
+jenkins:
+  systemMessage: "Testing"
+plugins:
+  - artifactId: git
+    source:
+      version: latest
+  - artifactId: workflow-step-api
+    groupId: org.jenkins-ci.plugins.workflow
+tool:
+  git:
+    installations:
+    - home: "git"
+      name: "Default"

--- a/plugin-management-cli/src/test/resources/plugins.yaml
+++ b/plugin-management-cli/src/test/resources/plugins.yaml
@@ -15,8 +15,9 @@ plugins:
     source:
       url: http://ftp-chi.osuosl.org/pub/jenkins/plugins/script-security/1.56/script-security.hpi
   - artifactId: workflow-step-api
+    groupId: org.jenkins-ci.plugins.workflow
     source:
-      version: "incrementals;org.jenkins-ci.plugins.workflow;2.19-rc289.d09828a05a74"
+      version: 2.19-rc289.d09828a05a74
   - artifactId: matrix-project
     source:
       url: httttp://ftp-chi.osuosl.org/pub/jenkins/plugins/matrix-project/1.7.1/matrix-project.hpi

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/Plugin.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/Plugin.java
@@ -18,7 +18,6 @@ public class Plugin {
     private List<Plugin> dependents;
 
 
-
     public Plugin(String name, String version, String url, String groupId) {
         this.originalName = name;
         this.name = name;
@@ -28,7 +27,6 @@ public class Plugin {
         this.version = new VersionNumber(version);
         this.url = url;
         this.groupId = groupId;
-
         dependencies = new ArrayList<>();
         dependents = new ArrayList<>();
     }
@@ -66,7 +64,6 @@ public class Plugin {
     public void setGroupId(String groupId) {
         this.groupId = groupId;
     }
-
 
     public String getName() {
         return name;

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/Plugin.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/Plugin.java
@@ -10,13 +10,16 @@ public class Plugin {
     private String name;
     private String originalName;
     private VersionNumber version;
+    private String groupId;
     private String url;
     private File file;
     private boolean isPluginOptional;
     private List<Plugin> dependencies;
     private List<Plugin> dependents;
 
-    public Plugin(String name, String version, String url) {
+
+
+    public Plugin(String name, String version, String url, String groupId) {
         this.originalName = name;
         this.name = name;
         if (StringUtils.isEmpty(version)) {
@@ -24,9 +27,10 @@ public class Plugin {
         }
         this.version = new VersionNumber(version);
         this.url = url;
-        this.dependencies = new ArrayList<>();
-        this.dependents = new ArrayList<>();
+        this.groupId = groupId;
 
+        dependencies = new ArrayList<>();
+        dependents = new ArrayList<>();
     }
 
     public Plugin(String name, String version, boolean isPluginOptional) {
@@ -59,6 +63,11 @@ public class Plugin {
         this.isPluginOptional = isPluginOptional;
     }
 
+    public void setGroupId(String groupId) {
+        this.groupId = groupId;
+    }
+
+
     public String getName() {
         return name;
     }
@@ -85,6 +94,10 @@ public class Plugin {
 
     public String getOriginalName() {
         return originalName;
+    }
+
+    public String getGroupId() {
+        return groupId;
     }
 
     public void setDependencies(List<Plugin> dependencies) {

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -438,14 +438,11 @@ public class PluginManager {
             urlString = String.format("%s/latest/%s.hpi", jenkinsUcLatest, pluginName);
         } else if (pluginVersion.equals("experimental")) {
             urlString = String.format("%s/latest/%s.hpi", cfg.getJenkinsUcExperimental(), pluginName);
-        } else if (pluginVersion.contains("incrementals")) {
-            System.out.println("plugin version " + pluginVersion);
-            String[] incrementalsVersionInfo = pluginVersion.split(";");
-            String groupId = incrementalsVersionInfo[1];
-            String incrementalsVersion = incrementalsVersionInfo[2];
+        } else if (!StringUtils.isEmpty(plugin.getGroupId())) {
+            String groupId = plugin.getGroupId();
             groupId = groupId.replace(".", "/");
             String incrementalsVersionPath =
-                    String.format("%s/%s/%s-%s.hpi", pluginName, incrementalsVersion, pluginName, incrementalsVersion);
+                    String.format("%s/%s/%s-%s.hpi", pluginName, pluginVersion, pluginName, pluginVersion);
             urlString =
                     String.format("%s/%s/%s", cfg.getJenkinsIncrementalsRepoMirror(), groupId, incrementalsVersionPath);
         } else {

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
@@ -204,49 +204,29 @@ public class PluginManagerTest {
 
         Assert.assertEquals("pluginURL", pm.getPluginDownloadUrl(plugin));
 
-        plugin.setUrl("");
+        Plugin pluginNoUrl = new Plugin("pluginName", "latest", null, null);
         pm.setJenkinsUCLatest("https://updates.jenkins.io/2.176");
-
         VersionNumber latestVersion = new VersionNumber("latest");
-
-        plugin.setVersion(latestVersion);
-
         String latestUrl = pm.getJenkinsUCLatest() + "/latest/pluginName.hpi";
+        Assert.assertEquals(latestUrl, pm.getPluginDownloadUrl(pluginNoUrl));
 
-        Assert.assertEquals(latestUrl, pm.getPluginDownloadUrl(plugin));
+        Plugin pluginNoVersion = new Plugin("pluginName", null, null, null);
+        Assert.assertEquals(latestUrl, pm.getPluginDownloadUrl(pluginNoVersion));
 
-        VersionNumber noVersion = new VersionNumber("");
-
-        plugin.setVersion(noVersion);
-
-        Assert.assertEquals(latestUrl, pm.getPluginDownloadUrl(plugin));
-
-        VersionNumber experimentalVersion = new VersionNumber("experimental");
-
-        plugin.setVersion(experimentalVersion);
-
+        Plugin pluginExperimentalVersion = new Plugin("pluginName", "experimental", null, null);
         String experimentalUrl = cfg.getJenkinsUcExperimental() + "/latest/pluginName.hpi";
-        Assert.assertEquals(experimentalUrl, pm.getPluginDownloadUrl(plugin));
+        Assert.assertEquals(experimentalUrl, pm.getPluginDownloadUrl(pluginExperimentalVersion));
 
-        VersionNumber version =
-                new VersionNumber("2.19-rc289.d09828a05a74");
-
-        plugin.setVersion(version);
-        plugin.setGroupId("org.jenkins-ci.plugins.pluginName");
+        Plugin pluginIncrementalRepo = new Plugin("pluginName", "2.19-rc289.d09828a05a74", null, "org.jenkins-ci.plugins.pluginName");
 
         String incrementalUrl = cfg.getJenkinsIncrementalsRepoMirror() +
                 "/org/jenkins-ci/plugins/pluginName/pluginName/2.19-rc289.d09828a05a74/pluginName-2.19-rc289.d09828a05a74.hpi";
 
-        Assert.assertEquals(incrementalUrl, pm.getPluginDownloadUrl(plugin));
+        Assert.assertEquals(incrementalUrl, pm.getPluginDownloadUrl(pluginIncrementalRepo));
 
-        VersionNumber otherVersion = new VersionNumber("otherversion");
-
-        plugin.setVersion(otherVersion);
-        plugin.setGroupId("");
-
+        Plugin pluginOtherVersion = new Plugin("pluginName", "otherversion", null, null);
         String otherURL = cfg.getJenkinsUc() + "/download/plugins/pluginName/otherversion/pluginName.hpi";
-
-        Assert.assertEquals(otherURL, pm.getPluginDownloadUrl(plugin));
+        Assert.assertEquals(otherURL, pm.getPluginDownloadUrl(pluginOtherVersion));
     }
 
 

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
@@ -190,7 +190,7 @@ public class PluginManagerTest {
         //File pluginDir = cfg.getPluginDir();
         //File tmp3 = File.createTempFile("test", ".jpi", pluginDir);
 
-        Plugin plugin = new Plugin("pluginName", "pluginVersion", "pluginURL");
+        Plugin plugin = new Plugin("pluginName", "pluginVersion", "pluginURL", null);
 
         JarFile pluginJpi = Mockito.mock(JarFile.class);
 
@@ -200,7 +200,7 @@ public class PluginManagerTest {
 
     @Test
     public void getPluginDownloadUrlTest() {
-        Plugin plugin = new Plugin("pluginName", "pluginVersion", "pluginURL");
+        Plugin plugin = new Plugin("pluginName", "pluginVersion", "pluginURL", null);
 
         Assert.assertEquals("pluginURL", pm.getPluginDownloadUrl(plugin));
 
@@ -228,10 +228,11 @@ public class PluginManagerTest {
         String experimentalUrl = cfg.getJenkinsUcExperimental() + "/latest/pluginName.hpi";
         Assert.assertEquals(experimentalUrl, pm.getPluginDownloadUrl(plugin));
 
-        VersionNumber incrementalVersion =
-                new VersionNumber("incrementals;org.jenkins-ci.plugins.pluginName;2.19-rc289.d09828a05a74");
+        VersionNumber version =
+                new VersionNumber("2.19-rc289.d09828a05a74");
 
-        plugin.setVersion(incrementalVersion);
+        plugin.setVersion(version);
+        plugin.setGroupId("org.jenkins-ci.plugins.pluginName");
 
         String incrementalUrl = cfg.getJenkinsIncrementalsRepoMirror() +
                 "/org/jenkins-ci/plugins/pluginName/pluginName/2.19-rc289.d09828a05a74/pluginName-2.19-rc289.d09828a05a74.hpi";
@@ -241,6 +242,7 @@ public class PluginManagerTest {
         VersionNumber otherVersion = new VersionNumber("otherversion");
 
         plugin.setVersion(otherVersion);
+        plugin.setGroupId("");
 
         String otherURL = cfg.getJenkinsUc() + "/download/plugins/pluginName/otherversion/pluginName.hpi";
 


### PR DESCRIPTION
Adds support for using groupId and versions to specify plugins that should be downloaded from the incrementals repository.  If a user enters a groupId, tool will assume they want to download plugins from incremental Id. In other words, they can't enter a groupId and try to download from a different url or update center. Maybe this is too rigid? Also updated the REAME yaml example to include real plugin names since Joseph thought what was there before was confusing.

Original PR for adding yaml support: https://github.com/jenkinsci/plugin-installation-manager-tool/pull/30

Jenkins Jira: 
https://issues.jenkins-ci.org/browse/JENKINS-58147