### PR TITLE
Update jar name - post incrementals cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The plugin manager downloads plugins and their dependencies into a folder so tha
 #### Getting Started
 ```
 mvn clean install 
-java -jar plugin-management-cli/target/plugin-management-tool.jar --war /file/path/jenkins.war --plugin-file /file/path/plugins.txt --plugins delivery-pipeline-plugin:1.3.2 deployit-plugin
+java -jar plugin-management-cli/target/jenkins-plugin-manager-*.jar --war /file/path/jenkins.war --plugin-file /file/path/plugins.txt --plugins delivery-pipeline-plugin:1.3.2 deployit-plugin
 ```
 
 #### CLI Options
@@ -84,7 +84,7 @@ If an url is included, then a placeholder should be included for the version. Ex
 If a plugin to be downloaded from the incrementals repository is requested using the -plugins option from the CLI, the plugin name should be enclosed in quotes, since the semi-colon is otherwise interpretted as the end of the command.
 
 ```
-java -jar plugin-management-cli/target/plugin-management-tool.jar -p "workflow-support:incrementals;org.jenkins-ci.plugins.workflow;2.19-rc289.d09828a05a74"
+java -jar plugin-management-cli/target/jenkins-plugin-manager-*.jar -p "workflow-support:incrementals;org.jenkins-ci.plugins.workflow;2.19-rc289.d09828a05a74"
 ```
 
 #### Other Information

--- a/plugin-management-cli/pom.xml
+++ b/plugin-management-cli/pom.xml
@@ -47,6 +47,8 @@
                         </goals>
                         <phase>package</phase>
                         <configuration>
+                            <finalName>jenkins-plugin-manager-${project.version}</finalName>
+                            <appendAssemblyId>false</appendAssemblyId>
                             <descriptorRefs>
                                 <descriptorRef>jar-with-dependencies</descriptorRef>
                             </descriptorRefs>


### PR DESCRIPTION
After https://github.com/jenkinsci/plugin-installation-manager-tool/pull/54 the jar name went back to including the jar-with-dependencies classifier as for incrementals to pick up the version it needs to have the version number in it. 

https://repo.jenkins-ci.org/incrementals/io/jenkins/plugin-management/plugin-management-cli/0.1-alpha-9-rc229.27bb3f48fcf7/

Here's a change to make it more user friendly imo

It drops the classifier and prefixes the uber jar with jenkins (up for debate but I figured it was good if someone was going to install it somewhere to have it prefixed with jenkins

```
$ ll plugin-management-cli/target/
total 7768
   0 drwxr-xr-x  15 timja  staff   480B 31 Jul 08:21 .
   0 drwxr-xr-x   6 timja  staff   192B 31 Jul 08:22 ..
   0 drwxr-xr-x   2 timja  staff    64B 31 Jul 08:21 archive-tmp
   8 -rw-r--r--   1 timja  staff   1.6K 31 Jul 08:21 checkstyle-cachefile
   8 -rw-r--r--   1 timja  staff   770B 31 Jul 08:21 checkstyle-checker.xml
   8 -rw-r--r--   1 timja  staff   1.6K 31 Jul 08:21 checkstyle-result.xml
   0 drwxr-xr-x   4 timja  staff   128B 31 Jul 08:21 classes
   0 drwxr-xr-x   3 timja  staff    96B 31 Jul 08:21 generated-sources
   0 drwxr-xr-x   3 timja  staff    96B 31 Jul 08:21 generated-test-sources
7696 -rw-r--r--   1 timja  staff   3.8M 31 Jul 08:21 jenkins-plugin-manager-0.1-alpha-9-SNAPSHOT.jar
   0 drwxr-xr-x   3 timja  staff    96B 31 Jul 08:21 maven-archiver
   0 drwxr-xr-x   3 timja  staff    96B 31 Jul 08:21 maven-status
  32 -rw-r--r--   1 timja  staff    13K 31 Jul 08:21 plugin-management-cli-0.1-alpha-9-SNAPSHOT.jar
  16 -rw-r--r--   1 timja  staff   4.4K 31 Jul 08:21 plugin-management-cli-0.1-alpha-9-SNAPSHOT.pom
   0 drwxr-xr-x  10 timja  staff   320B 31 Jul 08:21 test-classes
```