### PR TITLE
[JENKINS-58308] Add check for plugin and Jenkins version compatibility

### DIFF
--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/Plugin.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/Plugin.java
@@ -20,6 +20,7 @@ public class Plugin implements Comparable<Plugin> {
     private List<SecurityWarning> securityWarnings;
     private boolean latest;
     private boolean experimental;
+    private VersionNumber jenkinsVersion;
 
     public Plugin(String name, String version, String url, String groupId) {
         this.originalName = name;
@@ -84,6 +85,10 @@ public class Plugin implements Comparable<Plugin> {
         this.groupId = groupId;
     }
 
+    public void setJenkinsVersion(String jenkinsVersion) {
+        this.jenkinsVersion = new VersionNumber(jenkinsVersion);
+    }
+
     public String getName() {
         return name;
     }
@@ -130,6 +135,10 @@ public class Plugin implements Comparable<Plugin> {
 
     public Plugin getParent() {
         return parent;
+    }
+
+    public VersionNumber getJenkinsVersion() {
+        return jenkinsVersion;
     }
 
     public void setSecurityWarnings(List<SecurityWarning> securityWarnings) {

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -355,7 +355,7 @@ public class PluginManager {
             for (Plugin p : pluginsToBeDownloaded) {
                 if (p.getJenkinsVersion() != null) {
                     if (p.getJenkinsVersion().compareTo(jenkinsVersion) > 0) {
-                        System.out.println(
+                        throw new VersionCompatibilityException(
                                 String.format("%n%s (%s) requires a greater version of Jenkins (%s) than %s in %s",
                                         p.getName(), p.getVersion().toString(), p.getJenkinsVersion().toString(),
                                         jenkinsVersion.toString(), jenkinsWarFile.toString()));

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/VersionCompatibilityException.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/VersionCompatibilityException.java
@@ -1,0 +1,12 @@
+package io.jenkins.tools.pluginmanager.impl;
+
+public class VersionCompatibilityException extends RuntimeException {
+
+    public VersionCompatibilityException(String message) {
+        super(message);
+    }
+
+    public VersionCompatibilityException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
@@ -577,12 +577,9 @@ public class PluginManagerTest {
         assertEquals("", output.toString());
     }
 
-    @Test
+    @Test(expected = VersionCompatibilityException.class)
     public void checkVersionCompatibilityFailTest() throws IOException {
         pm.setJenkinsVersion(new VersionNumber("1.609.3"));
-
-        ByteArrayOutputStream output = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(output));
 
         Plugin plugin1 = new Plugin("plugin1", "1.0", null, null);
         plugin1.setJenkinsVersion("2.121.2");
@@ -592,10 +589,6 @@ public class PluginManagerTest {
 
         List<Plugin> pluginsToDownload = new ArrayList<>(Arrays.asList(plugin1, plugin2));
         pm.checkVersionCompatibility(pluginsToDownload);
-
-        assertEquals("plugin1 (1.0) requires a greater version of Jenkins (2.121.2) than 1.609.3 in "
-                        + Settings.DEFAULT_WAR,
-                output.toString().trim());
     }
 
     @Test

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
@@ -375,7 +375,7 @@ public class PluginManagerTest {
 
         JSONObject browserStackIntegration= new JSONObject();
         JSONObject browserStack1 = new JSONObject();
-        browserStack1.put("buildDate", "Jul 12, 2016");
+        browserStack1.put("requiredCore", "1.580.1");
         JSONArray dependencies1 = new JSONArray();
         JSONObject credentials1 = new JSONObject();
         credentials1.put("name", "credentials");
@@ -387,12 +387,12 @@ public class PluginManagerTest {
         junit1.put("version", "1.10");
 
         dependencies1.put(credentials1);
-              dependencies1.put(junit1);
+        dependencies1.put(junit1);
         browserStack1.put("dependencies", dependencies1);
         browserStackIntegration.put("1.0.0", browserStack1);
 
         JSONObject browserStack111 = new JSONObject();
-        browserStack111.put("buildDate", "Jul 02, 2018");
+        browserStack111.put("requiredCore", "1.580.1");
         JSONArray dependencies111 = new JSONArray();
         JSONObject credentials111 = new JSONObject();
         credentials111.put("name", "credentials");
@@ -409,7 +409,7 @@ public class PluginManagerTest {
         browserStackIntegration.put("1.1.1", browserStack111);
 
         JSONObject browserStack112 = new JSONObject();
-        browserStack112.put("buildDate", "Aug 09, 2018");
+        browserStack112.put("requiredCore", "1.653");
         JSONArray dependencies112 = new JSONArray();
         JSONObject credentials112 = new JSONObject();
         credentials112.put("name", "credentials");
@@ -556,6 +556,62 @@ public class PluginManagerTest {
         // currently fails since 2.5.3 matches pattern even though 2.5.1 is last effected version
         assertEquals(true, pm.warningExists(sshAgents1));
         assertEquals(false, pm.warningExists(sshAgents2));
+    }
+
+    @Test
+    public void checkVersionCompatibilityNullTest() {
+        pm.setJenkinsVersion(null);
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(output));
+
+        Plugin plugin1 = new Plugin("plugin1", "1.0", null, null);
+        plugin1.setJenkinsVersion("2.121.2");
+
+        Plugin plugin2 = new Plugin("plugin2", "2.1.1", null, null);
+        plugin2.setJenkinsVersion("1.609.3");
+
+        List<Plugin> pluginsToDownload = new ArrayList<>(Arrays.asList(plugin1, plugin2));
+        pm.checkVersionCompatibility(pluginsToDownload);
+
+        assertEquals("", output.toString());
+    }
+
+    @Test
+    public void checkVersionCompatibilityFailTest() throws IOException {
+        pm.setJenkinsVersion(new VersionNumber("1.609.3"));
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(output));
+
+        Plugin plugin1 = new Plugin("plugin1", "1.0", null, null);
+        plugin1.setJenkinsVersion("2.121.2");
+
+        Plugin plugin2 = new Plugin("plugin2", "2.1.1", null, null);
+        plugin2.setJenkinsVersion("1.609.3");
+
+        List<Plugin> pluginsToDownload = new ArrayList<>(Arrays.asList(plugin1, plugin2));
+        pm.checkVersionCompatibility(pluginsToDownload);
+
+        assertEquals("plugin1 (1.0) requires a greater version of Jenkins (2.121.2) than 1.609.3 in "
+                        + Settings.DEFAULT_WAR,
+                output.toString().trim());
+    }
+
+    @Test
+    public void checkVersionCompatibilityPassTest() {
+        pm.setJenkinsVersion(new VersionNumber("2.121.2"));
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(output));
+
+        Plugin plugin1 = new Plugin("plugin1", "1.0", null, null);
+        plugin1.setJenkinsVersion("2.121.2");
+
+        Plugin plugin2 = new Plugin("plugin2", "2.1.1", null, null);
+        plugin2.setJenkinsVersion("1.609.3");
+
+        assertEquals("", output.toString());
     }
 
     @Test
@@ -1449,6 +1505,7 @@ public class PluginManagerTest {
         mavenInvokerPlugin.put("dependencies", mavenInvokerDependencies);
 
         mavenInvokerPlugin.put("version", "2.4");
+        mavenInvokerPlugin.put("requiredCore", "2.89.4");
 
         pluginJson.put("maven-invoker-plugin", mavenInvokerPlugin);
 
@@ -1471,6 +1528,7 @@ public class PluginManagerTest {
 
         amazonEcsPlugin.put("dependencies", amazonEcsPluginDependencies);
         amazonEcsPlugin.put("version", "1.20");
+        amazonEcsPlugin.put("requiredCore", "2.107.3");
 
         pluginJson.put("amazon-ecs", amazonEcsPlugin);
 
@@ -1480,6 +1538,7 @@ public class PluginManagerTest {
 
         antPlugin.put("dependencies", antPluginDependencies);
         antPlugin.put("version", "1.9");
+        antPlugin.put("requiredVersion", "2.121.2");
 
         pluginJson.put("ant", antPlugin);
 


### PR DESCRIPTION
Should users actually be prevented from downloading plugins if there's a version incompatibility or should this just be a warning? 

https://issues.jenkins-ci.org/browse/JENKINS-58308