### PR TITLE
[JENKINS-59148] Add option for getting all of the latest dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ java -jar plugin-management-cli/target/jenkins-plugin-manager-*.jar --war /file/
 * `--view-security-warnings`: (optional) Set to true to show if any of the user specified plugins have security warnings
 * `--view-all-security-warnings`: (optional) Set to true to show all plugins that have security warnings.
 * `--available-updates`: (optional) Set to true to show if any requested plugins have newer versions available. If a Jenkins version-specific update center is available, the latest plugin version will be determined based on that update center's data.
+* `--latest`: (optional) Set to true to download the latest version of all dependencies, even if the version(s) of the requested plugin(s) are not the latest.
+* `--latest-specified`: (optional) Set to true to download latest dependencies of any plugin that is requested to have the latest version. All other plugin dependency versions are determined by the update center metadata or the plugin MANIFEST.MF.
 * `--jenkins-update-center`: (optional) Sets the main update center, which can also be set via the JENKINS_UC environment variable. If a CLI option is entered, it will override what is set in the environment variable. If not set via CLI option or environment variable, will default to https://updates.jenkins.io.
 * `--jenkins-experimental-update-center`: (optional) Sets the experimental update center, which can also be set via the JENKINS_UC_EXPERIMENTAL environment variable. If a CLI option is entered, it will override what is set in the environment variable. If not set via CLI option or environment variable, will default to https://updates.jenkins.io/experimental.
 * `--jenkins-incrementals-repo-mirror`: (optional) Sets the incrementals repository mirror, which can also be set via the JENKINS_INCREMENTALS_REPO_MIRROR environment variable. If a CLI option is entered, it will override what is set in the environment variable. If not set via CLI option or environment variable, will default to https://repo.jenkins-ci.org/incrementals.
@@ -91,7 +93,7 @@ java -jar plugin-management-cli/target/jenkins-plugin-manager-*.jar -p "workflow
 ```
 
 #### Other Information
-The plugin manager tries to use update center data to get the latest information about a plugin's dependencies. If this information is unavailable, it will use the dependency information from the downloaded plugin's MANIFEST.MF file.
+The plugin manager tries to use update center data to get the latest information about a plugin's dependencies. If this information is unavailable, it will use the dependency information from the downloaded plugin's MANIFEST.MF file. By default, the versions of the plugin dependencies are determined by the update center metadata or the plugin MANIFEST.MF file, but the user can specify other behavior using the `latest` or `latest-specified` options.
 
 For plugins listed in a .txt file, each plugin must be listed on a new line. Comments beginning with `#` will be filtered out.
 

--- a/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/CliOptions.java
+++ b/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/CliOptions.java
@@ -96,7 +96,7 @@ class CliOptions {
             handler = BooleanOptionHandler.class)
     private boolean useLatestSpecified;
 
-    @Option(name = "--latest-all", usage = "Set to true to download the latest version of all dependencies, even " +
+    @Option(name = "--latest", usage = "Set to true to download the latest version of all dependencies, even " +
             "if the version(s) of the requested plugin(s) are not the latest. By default, plugin dependency versions " +
             "will be determined by the update center metadata or plugin MANIFEST.MF",
             handler = BooleanOptionHandler.class)

--- a/plugin-management-cli/src/test/java/io/jenkins/tools/pluginmanager/cli/CliOptionsTest.java
+++ b/plugin-management-cli/src/test/java/io/jenkins/tools/pluginmanager/cli/CliOptionsTest.java
@@ -336,7 +336,7 @@ public class CliOptionsTest {
 
     @Test
     public void useLatestTest() throws CmdLineException {
-        parser.parseArgument("--latest-all");
+        parser.parseArgument("--latest");
         Config cfg = options.setup();
         assertEquals(true, cfg.isUseLatestAll());
     }
@@ -350,7 +350,7 @@ public class CliOptionsTest {
 
     @Test (expected = PluginDependencyStrategyException.class)
     public void useLatestSpecifiedAndLatestAllTest() throws CmdLineException {
-        parser.parseArgument("--latest-all", "--latest-specified");
+        parser.parseArgument("--latest", "--latest-specified");
         Config cfg = options.setup();
     }
 

--- a/plugin-management-cli/src/test/java/io/jenkins/tools/pluginmanager/cli/CliOptionsTest.java
+++ b/plugin-management-cli/src/test/java/io/jenkins/tools/pluginmanager/cli/CliOptionsTest.java
@@ -3,6 +3,7 @@ package io.jenkins.tools.pluginmanager.cli;
 import io.jenkins.tools.pluginmanager.config.Config;
 import io.jenkins.tools.pluginmanager.config.Settings;
 import io.jenkins.tools.pluginmanager.impl.Plugin;
+import io.jenkins.tools.pluginmanager.impl.PluginDependencyStrategyException;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -320,17 +321,37 @@ public class CliOptionsTest {
     }
 
     @Test
-    public void useLatestTest() throws CmdLineException {
-        parser.parseArgument("--latest");
+    public void useLatestSpecifiedTest() throws CmdLineException {
+        parser.parseArgument("--latest-specified");
         Config cfg = options.setup();
-        assertEquals(true, cfg.isUseLatest());
+        assertEquals(true, cfg.isUseLatestSpecified());
+    }
+
+    @Test
+    public void useNotLatestSpecifiedTest() throws CmdLineException {
+        parser.parseArgument();
+        Config cfg = options.setup();
+        assertEquals(false, cfg.isUseLatestSpecified());
+    }
+
+    @Test
+    public void useLatestTest() throws CmdLineException {
+        parser.parseArgument("--latest-all");
+        Config cfg = options.setup();
+        assertEquals(true, cfg.isUseLatestAll());
     }
 
     @Test
     public void useNotLatestTest() throws CmdLineException {
         parser.parseArgument();
         Config cfg = options.setup();
-        assertEquals(false, cfg.isUseLatest());
+        assertEquals(false, cfg.isUseLatestAll());
+    }
+
+    @Test (expected = PluginDependencyStrategyException.class)
+    public void useLatestSpecifiedAndLatestAllTest() throws CmdLineException {
+        parser.parseArgument("--latest-all", "--latest-specified");
+        Config cfg = options.setup();
     }
 
     @After

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Config.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Config.java
@@ -29,7 +29,8 @@ public class Config {
     private URL jenkinsUcExperimental;
     private URL jenkinsIncrementalsRepoMirror;
     private boolean doDownload;
-    private boolean useLatest;
+    private boolean useLatestSpecified;
+    private boolean useLatestAll;
 
     private Config(
             File pluginDir,
@@ -44,7 +45,8 @@ public class Config {
             URL jenkinsUcExperimental,
             URL jenkinsIncrementalsRepoMirror,
             boolean doDownload,
-            boolean useLatest
+            boolean useLatestSpecified,
+            boolean useLatestAll
     ) {
         this.pluginDir = pluginDir;
         this.showWarnings = showWarnings;
@@ -58,7 +60,9 @@ public class Config {
         this.jenkinsUcExperimental = jenkinsUcExperimental;
         this.jenkinsIncrementalsRepoMirror = jenkinsIncrementalsRepoMirror;
         this.doDownload = doDownload;
-        this.useLatest = useLatest;
+        this.useLatestSpecified = useLatestSpecified;
+        this.useLatestAll = useLatestAll;
+
     }
 
     public File getPluginDir() {
@@ -109,9 +113,11 @@ public class Config {
         return doDownload;
     }
 
-    public boolean isUseLatest() {
-        return useLatest;
+    public boolean isUseLatestSpecified() {
+        return useLatestSpecified;
     }
+
+    public boolean isUseLatestAll() { return useLatestAll; }
 
     public static Builder builder() {
         return new Builder();
@@ -130,7 +136,8 @@ public class Config {
         private URL jenkinsUcExperimental = Settings.DEFAULT_EXPERIMENTAL_UPDATE_CENTER;
         private URL jenkinsIncrementalsRepoMirror = Settings.DEFAULT_INCREMENTALS_REPO_MIRROR;
         private boolean doDownload;
-        private boolean useLatest;
+        private boolean useLatestSpecified;
+        private boolean useLatestAll;
 
         private Builder() {
         }
@@ -195,8 +202,13 @@ public class Config {
             return this;
         }
 
-        public Builder withUseLatest(boolean useLatest) {
-            this.useLatest = useLatest;
+        public Builder withUseLatestSpecified(boolean useLatestSpecifed) {
+            this.useLatestSpecified = useLatestSpecifed;
+            return this;
+        }
+
+        public Builder withUseLatestAll(boolean useLatestAll) {
+            this.useLatestAll = useLatestAll;
             return this;
         }
 
@@ -214,7 +226,8 @@ public class Config {
                     jenkinsUcExperimental,
                     jenkinsIncrementalsRepoMirror,
                     doDownload,
-                    useLatest
+                    useLatestSpecified,
+                    useLatestAll
             );
         }
 

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginDependencyStrategyException.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginDependencyStrategyException.java
@@ -1,0 +1,12 @@
+package io.jenkins.tools.pluginmanager.impl;
+
+public class PluginDependencyStrategyException extends RuntimeException {
+
+    public PluginDependencyStrategyException(String message) {
+        super(message);
+    }
+
+    public PluginDependencyStrategyException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -69,7 +69,8 @@ public class PluginManager {
     private JSONObject pluginInfoJson;
     private JSONObject latestPlugins;
     private boolean verbose;
-    private boolean useLatest;
+    private boolean useLatestSpecified;
+    private boolean useLatestAll;
 
     public static final String SEPARATOR = File.separator;
 
@@ -84,7 +85,8 @@ public class PluginManager {
         allPluginsAndDependencies = new HashMap<>();
         verbose = cfg.isVerbose();
         jenkinsUcLatest = cfg.getJenkinsUc().toString();
-        useLatest = cfg.isUseLatest();
+        useLatestSpecified = cfg.isUseLatestSpecified();
+        useLatestAll = cfg.isUseLatestAll();
     }
 
     /**
@@ -98,6 +100,11 @@ public class PluginManager {
             } catch (IOException e) {
                 throw new DirectoryCreationException("Unable to create plugin directory", e);
             }
+        }
+
+        if (useLatestSpecified && useLatestAll) {
+            throw new PluginDependencyStrategyException("Only one plugin dependency version strategy can be selected " +
+                    "at a time");
         }
 
         jenkinsVersion = getJenkinsVersionFromWar();
@@ -589,7 +596,7 @@ public class PluginManager {
                     String pluginName = pluginInfo[0];
                     String pluginVersion = pluginInfo[1];
                     Plugin dependentPlugin = new Plugin(pluginName, pluginVersion, null, null);
-                    if (useLatest && plugin.isLatest()) {
+                    if (useLatestSpecified && plugin.isLatest() || useLatestAll) {
                         VersionNumber latestPluginVersion = getLatestPluginVersion(pluginName);
                         dependentPlugin.setVersion(latestPluginVersion);
                         dependentPlugin.setLatest(true);
@@ -637,7 +644,7 @@ public class PluginManager {
                 String pluginName = dependency.getString("name");
                 String pluginVersion = dependency.getString("version");
                 Plugin dependentPlugin = new Plugin(pluginName, pluginVersion, null, null);
-                if (useLatest && plugin.isLatest()) {
+                if (useLatestSpecified && plugin.isLatest() || useLatestAll) {
                     VersionNumber latestPluginVersion = getLatestPluginVersion(pluginName);
                     dependentPlugin.setVersion(latestPluginVersion);
                     dependentPlugin.setLatest(true);


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-59148

Based off of feedback from Oleg, the current functionality of having all dependencies be on the latest version should also be supported since that's how the install-plugins bash script is currently working. 