### PR TITLE
[JENKINS-59173] Fix JDK 11 support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,9 @@
 // While this isn't a plugin, it is much simpler to reuse the pipeline code for CI
 // allowing easy windows / linux testing and producing incrementals
 // the only feature that buildPlugin has that relates to plugins is allowing you to test against multiple jenkins versions
-buildPlugin()
+buildPlugin(configurations: [
+        [ platform: "linux", jdk: "8", jenkins: null ],
+        [ platform: "windows", jdk: "8", jenkins: null ],
+        [ platform: "linux", jdk: "11", jenkins: null, javaLevel: "8" ],
+        [ platform: "windows", jdk: "11", jenkins: null, javaLevel: "8" ]
+    ])

--- a/plugin-management-cli/pom.xml
+++ b/plugin-management-cli/pom.xml
@@ -70,4 +70,18 @@
         </resources>
     </build>
 
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <configuration>
+                        <source>8</source>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
 </project>

--- a/plugin-management-cli/pom.xml
+++ b/plugin-management-cli/pom.xml
@@ -61,6 +61,13 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                </configuration>
+            </plugin>
         </plugins>
         <resources>
             <resource>
@@ -68,20 +75,6 @@
                 <filtering>true</filtering>
             </resource>
         </resources>
-    </build>
-
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <configuration>
-                        <source>8</source>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
     </build>
 
 </project>

--- a/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/CliOptions.java
+++ b/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/CliOptions.java
@@ -1,5 +1,6 @@
 package io.jenkins.tools.pluginmanager.cli;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.jenkins.tools.pluginmanager.config.Config;
 import io.jenkins.tools.pluginmanager.config.Settings;
 import io.jenkins.tools.pluginmanager.impl.Plugin;
@@ -344,6 +345,7 @@ class CliOptions {
     /**
      * Prints out the Plugin Management Tool version
      */
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
     public void showVersion() {
         try (InputStream propertyInputStream = getPropertiesInputStream("/.properties")) {
             if (propertyInputStream == null) {

--- a/plugin-management-library/pom.xml
+++ b/plugin-management-library/pom.xml
@@ -47,18 +47,17 @@
     </dependencies>
 
     <build>
-            <pluginManagement>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <configuration>
-                            <source>8</source>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </pluginManagement>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <configuration>
+                        <source>8</source>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
-
 
 </project>

--- a/plugin-management-library/pom.xml
+++ b/plugin-management-library/pom.xml
@@ -46,5 +46,19 @@
         </dependency>
     </dependencies>
 
+    <build>
+            <pluginManagement>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <source>8</source>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </pluginManagement>
+    </build>
+
 
 </project>

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -1,5 +1,6 @@
 package io.jenkins.tools.pluginmanager.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.util.VersionNumber;
 import io.jenkins.tools.pluginmanager.config.Config;
 import io.jenkins.tools.pluginmanager.config.Settings;
@@ -374,6 +375,7 @@ public class PluginManager {
      * center url String to include Jenkins Version. Otherwise, sets update center url to match the update center in
      * the configuration class
      */
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     public void checkAndSetLatestUpdateCenter() {
         //check if version specific update center
         if (jenkinsVersion != null && !StringUtils.isEmpty(jenkinsVersion.toString())) {
@@ -822,6 +824,7 @@ public class PluginManager {
      *                     be null
      * @return true if download is successful, false otherwise
      */
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     public boolean downloadToFile(String urlString, Plugin plugin, File fileLocation) {
         File pluginFile;
         if (fileLocation == null) {
@@ -940,6 +943,7 @@ public class PluginManager {
      *
      * @return list of names of plugins that are currently installed in the war
      */
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     public Map<String, Plugin> bundledPlugins() {
         Map<String, Plugin> bundledPlugins = new HashMap<>();
 

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -537,8 +537,8 @@ public class PluginManager {
 
     /**
      *
-     * @param pluginName
-     * @return
+     * @param pluginName the name of the plugin
+     * @return latest version of the specified plugin
      */
     public VersionNumber getLatestPluginVersion(String pluginName) {
         if (!latestPlugins.has(pluginName)) {

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
@@ -1646,6 +1646,7 @@ public class PluginManagerTest {
     }
 
     @Test
+    @PrepareForTest({HttpClients.class, HttpClientContext.class, HttpHost.class})
     public void bundledPluginsTest() {
         URL warURL = this.getClass().getResource("/bundledplugintest.war");
         File testWar = new File(warURL.getFile());


### PR DESCRIPTION
@PrepareForTest when used on some of the classes
will cause an issue because those classes are mocks.

JDK 8 doesn't have an issue with private fields/methods,
but JDK 11 does. Adding the @PrepareForTest annotation
to the specific test method that was failing only makes the
classes listed mocks.