### PR TITLE
PR#76 CI Test as 'trusted' user

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,9 @@
 // While this isn't a plugin, it is much simpler to reuse the pipeline code for CI
 // allowing easy windows / linux testing and producing incrementals
 // the only feature that buildPlugin has that relates to plugins is allowing you to test against multiple jenkins versions
-buildPlugin()
+buildPlugin(configurations: [
+        [ platform: "linux", jdk: "8", jenkins: null ],
+        [ platform: "windows", jdk: "8", jenkins: null ],
+        [ platform: "linux", jdk: "11", jenkins: null, javaLevel: "8" ],
+        [ platform: "windows", jdk: "11", jenkins: null, javaLevel: "8" ]
+    ])

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -537,8 +537,8 @@ public class PluginManager {
 
     /**
      *
-     * @param pluginName
-     * @return
+     * @param pluginName the name of the plugin
+     * @return latest version of the specified plugin
      */
     public VersionNumber getLatestPluginVersion(String pluginName) {
         if (!latestPlugins.has(pluginName)) {

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
@@ -1646,6 +1646,7 @@ public class PluginManagerTest {
     }
 
     @Test
+    @PrepareForTest({HttpClients.class, HttpClientContext.class, HttpHost.class})
     public void bundledPluginsTest() {
         URL warURL = this.getClass().getResource("/bundledplugintest.war");
         File testWar = new File(warURL.getFile());


### PR DESCRIPTION
@PrepareForTest when used on some of the classes
will cause an issue because those classes are mocks.

JDK 8 doesn't have an issue with private fields/methods,
but JDK 11 does. Adding the @PrepareForTest annotation
to the specific test method that was failing only makes the
classes listed mocks.