### PR TITLE
[JENKINS-60637] Add retry to plugin file download

### DIFF
--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -869,8 +869,12 @@ public class PluginManager {
 
         boolean success = true;
         for (int i = 0; i < maxRetries; i++) {
-            if (pluginFile.exists()) {
-                Files.delete(pluginFile.toPath());
+            try {
+                if (pluginFile.exists()) {
+                    Files.delete(pluginFile.toPath());
+                }
+            } catch (IOException) {
+                logVerbose(String.format("Unable to delete %s before retry %d",pluginFile,i+1);
             }
 
             try (CloseableHttpClient httpclient = HttpClients.custom().useSystemProperties()

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -873,7 +873,7 @@ public class PluginManager {
                 if (pluginFile.exists()) {
                     Files.delete(pluginFile.toPath());
                 }
-            } catch (IOException) {
+            } catch (IOException e) {
                 logVerbose(String.format("Unable to delete %s before retry %d",pluginFile,i+1);
             }
 

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -874,7 +874,7 @@ public class PluginManager {
                     Files.delete(pluginFile.toPath());
                 }
             } catch (IOException e) {
-                logVerbose(String.format("Unable to delete %s before retry %d",pluginFile,i+1);
+                logVerbose(String.format("Unable to delete %s before retry %d",pluginFile,i+1));
             }
 
             try (CloseableHttpClient httpclient = HttpClients.custom().useSystemProperties()

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -42,12 +42,14 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHost;
+import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.client.utils.URIUtils;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
 import org.apache.http.impl.client.HttpClients;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -80,6 +82,8 @@ public class PluginManager {
     private boolean useLatestAll;
 
     public static final String SEPARATOR = File.separator;
+
+    private static final int DEFAULT_MAX_RETRIES = 3;
 
     public PluginManager(Config cfg) {
         this.cfg = cfg;
@@ -838,43 +842,81 @@ public class PluginManager {
      *                     be null
      * @return true if download is successful, false otherwise
      */
-    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     public boolean downloadToFile(String urlString, Plugin plugin, File fileLocation) {
+        return downloadToFile(urlString, plugin, fileLocation, DEFAULT_MAX_RETRIES);
+    }
+
+    /**
+     * Downloads a plugin from a url to a file.
+     *
+     * @param urlString    String url to download the plugin from
+     * @param plugin       Plugin object representing plugin to be downloaded
+     * @param fileLocation contains the temp file if the plugin is downloaded so that dependencies can be parsed from
+     *                     the manifest, if the plugin will be downloaded to the plugin download location, this will
+     *                     be null
+     * @param maxRetries   Maximum number of times to retry the download before failing
+     * @return true if download is successful, false otherwise
+     */
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
+    public boolean downloadToFile(String urlString, Plugin plugin, File fileLocation, int maxRetries) {
         File pluginFile;
         if (fileLocation == null) {
-            pluginFile = new File(refDir + SEPARATOR + plugin.getArchiveFileName());
+            pluginFile = new File(refDir, plugin.getArchiveFileName());
             System.out.println("\nDownloading plugin " + plugin.getName() + " from url: " + urlString);
         } else {
             pluginFile = fileLocation;
         }
-        try (CloseableHttpClient httpclient = HttpClients.createSystem()) {
-            HttpClientContext context = HttpClientContext.create();
-            HttpHead httphead = new HttpHead(urlString);
-            try (CloseableHttpResponse response = httpclient.execute(httphead, context)) {
-                HttpHost target = context.getTargetHost();
-                List<URI> redirectLocations = context.getRedirectLocations();
-                // Expected to be an absolute URI
-                URI location = URIUtils.resolve(httphead.getURI(), target, redirectLocations);
-                FileUtils.copyURLToFile(location.toURL(), pluginFile);
-            } catch (URISyntaxException | IOException e) {
-                logVerbose(String.format("Unable to resolve plugin URL %s, or download plugin %s to file",
-                        urlString, plugin.getName()));
-                return false;
+
+        boolean success = true;
+        for (int i = 0; i < maxRetries; i++) {
+            if (pluginFile.exists()) {
+                pluginFile.delete();
             }
-        } catch (IOException e) {
-            System.out.println("Unable to create HTTP connection to download plugin");
-            return false;
+
+            try (CloseableHttpClient httpclient = HttpClients.custom().useSystemProperties()
+                    .addInterceptorLast((HttpRequestInterceptor) (request, context) -> {
+                        throw new IOException("Planned");
+                    })
+                    .setRetryHandler(new DefaultHttpRequestRetryHandler(maxRetries, false))
+                    .build()) {
+                HttpClientContext context = HttpClientContext.create();
+                HttpHead httphead = new HttpHead(urlString);
+                try (CloseableHttpResponse response = httpclient.execute(httphead, context)) {
+                    HttpHost target = context.getTargetHost();
+                    List<URI> redirectLocations = context.getRedirectLocations();
+                    // Expected to be an absolute URI
+                    URI location = URIUtils.resolve(httphead.getURI(), target, redirectLocations);
+                    FileUtils.copyURLToFile(location.toURL(), pluginFile);
+                } catch (URISyntaxException | IOException e) {
+                    logVerbose(String.format("Unable to resolve plugin URL %s, or download plugin %s to file",
+                            urlString, plugin.getName()));
+                    success = false;
+                }
+            } catch (IOException e) {
+                System.out.println("Unable to create HTTP connection to download plugin");
+                success = false;
+            }
+
+            // Check integrity of plugin file
+            if (success) {
+                try (JarFile pluginJpi = new JarFile(pluginFile)) {
+                    plugin.setFile(pluginFile);
+                } catch (IOException e) {
+                    System.out.println("Downloaded file for " + plugin.getName() + " is not a valid ZIP");
+                    success = false;
+                }
+            }
+
+            // both the download and zip validation passed
+            if(success) {
+                break;
+            }
         }
 
-        // Check integrity of plugin file
-        try (JarFile pluginJpi = new JarFile(pluginFile)) {
-            plugin.setFile(pluginFile);
-        } catch (IOException e) {
+        if (!success) {
             failedPlugins.add(plugin);
-            System.out.println("Downloaded file is not a valid ZIP");
-            return false;
         }
-        return true;
+        return success;
     }
 
     /**

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -875,7 +875,7 @@ public class PluginManager {
 
             try (CloseableHttpClient httpclient = HttpClients.custom().useSystemProperties()
                     .addInterceptorLast((HttpRequestInterceptor) (request, context) -> {
-                        throw new IOException("Planned");
+                        throw new IOException("Retry on any failure");
                     })
                     .setRetryHandler(new DefaultHttpRequestRetryHandler(maxRetries, false))
                     .build()) {

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -870,7 +870,7 @@ public class PluginManager {
         boolean success = true;
         for (int i = 0; i < maxRetries; i++) {
             if (pluginFile.exists()) {
-                pluginFile.delete();
+                Files.delete(pluginFile.toPath());
             }
 
             try (CloseableHttpClient httpclient = HttpClients.custom().useSystemProperties()

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
@@ -32,6 +32,7 @@ import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.client.utils.URIUtils;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -64,7 +65,7 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({HttpClients.class, PluginManager.class, HttpClientContext.class, URIUtils.class, HttpHost.class,
-        URI.class, FileUtils.class, URL.class, IOUtils.class, Files.class})
+        URI.class, FileUtils.class, URL.class, IOUtils.class, Files.class, HttpClientBuilder.class})
 @PowerMockIgnore({"javax.net.ssl.*","javax.security.*", "javax.net.*"})
 public class PluginManagerTest {
     private PluginManager pm;
@@ -1499,7 +1500,10 @@ public class PluginManagerTest {
         mockStatic(HttpClients.class);
         CloseableHttpClient httpclient = mock(CloseableHttpClient.class);
 
-        when(HttpClients.createSystem()).thenReturn(httpclient);
+        HttpClientBuilder builder = mock(HttpClientBuilder.class);
+        when(HttpClients.custom()).thenReturn(builder);
+        when(builder.build()).thenReturn(httpclient);
+
         HttpHead httphead = mock(HttpHead.class);
 
         mockStatic(HttpClientContext.class);


### PR DESCRIPTION
Adds retry to the plugin file download. Uses the built-in method for download retry, but will also retry if the downloaded file does not validate as a valid zip file.