### PR TITLE
[JENKINS-58110] - Added failed plugins output to failed-plugins.txt

### DIFF
--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -7,6 +7,7 @@ import io.jenkins.tools.pluginmanager.config.Settings;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.FileOutputStream;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
@@ -138,6 +139,7 @@ public class PluginManager {
         if (cfg.doDownload()) {
             downloadPlugins(pluginsToBeDownloaded);
         }
+        outputFailedPlugins();
         System.out.println("Done");
     }
 
@@ -415,6 +417,39 @@ public class PluginManager {
                         "Unable to check if version specific update center for Jenkins version " + jenkinsVersion);
             }
         }
+    }
+    /**
+     * Outputs a list of plugins which have failed to download
+     */
+    public void outputFailedPlugins() {
+        if (failedPlugins.size() > 0) {
+            System.out.println("Some plugins failed to download: ");
+            //Create a new Failed Plugins text file
+            File failedPluginsFile = new File(refDir.getAbsolutePath() + File.separator + "failed-plugins.txt");
+
+            if (!failedPluginsFile.exists()) {
+                try {
+                    failedPluginsFile.createNewFile();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                    System.out.println("File cannot be created at the path: " + failedPluginsFile
+                        .getAbsolutePath());
+                }
+            }
+
+            try {
+                String newLine = System.getProperty("line.separator");
+                FileWriter fileWriter = new FileWriter(failedPluginsFile.getPath());
+                for (Plugin plugin : failedPlugins) {
+                    String failedPluginName = plugin.getName();
+                    fileWriter.write(failedPluginName + newLine);
+                    System.out.println(failedPluginName);
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+        System.exit(1);
     }
 
     /**

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -423,9 +423,9 @@ public class PluginManager {
      */
     public void outputFailedPlugins() {
         if (failedPlugins.size() > 0) {
-            System.out.println("Some plugins failed to download: ");
+            System.out.println(failedPlugins.size() + " plugin(s) failed to download: ");
             //Create a new Failed Plugins text file
-            File failedPluginsFile = new File(refDir.getAbsolutePath() + File.separator + "failed-plugins.txt");
+            File failedPluginsFile = new File(refDir.getAbsolutePath(), "failed-plugins.txt");
 
             if (!failedPluginsFile.exists()) {
                 try {

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -431,9 +431,8 @@ public class PluginManager {
                 try {
                     failedPluginsFile.createNewFile();
                 } catch (IOException e) {
-                    e.printStackTrace();
-                    System.out.println("File cannot be created at the path: " + failedPluginsFile
-                        .getAbsolutePath());
+                    logVerbose(String.format("File cannot be created at the path: " + failedPluginsFile
+                        .getAbsolutePath()));
                 }
             }
 
@@ -446,10 +445,9 @@ public class PluginManager {
                     System.out.println(failedPluginName);
                 }
             } catch (Exception e) {
-                e.printStackTrace();
+                logVerbose(String.format("Unable to write to file: " + e.getMessage()));
             }
         }
-        System.exit(1);
     }
 
     /**


### PR DESCRIPTION
This PR deals with the addition of failed plugins to a new file "failed-plugins.txt".
Reference : https://issues.jenkins-ci.org/browse/JENKINS-58110

To-Do

- [ ]  Write a test case
- [ ]  Add option to change "failed-plugins.txt" path.