### PR TITLE
Add environmenet variable for overriding plugin info location + document proxy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,16 @@ The plugin manager downloads plugins and their dependencies into a folder so tha
 ### Usage
 
 #### Getting Started
+
+Download the latest plugin-management-cli jar [from here](https://github.com/jenkinsci/plugin-installation-manager-tool/releases/latest) and run it as shown below.
+
+```bash
+java -jar /file/path/plugin-management-cli-*.jar --war /file/path/jenkins.war --plugin-file /file/path/plugins.txt --plugins delivery-pipeline-plugin:1.3.2 deployit-plugin
 ```
+
+Alternatively you may build it yourself from source:
+
+```bash
 mvn clean install 
 java -jar plugin-management-cli/target/jenkins-plugin-manager-*.jar --war /file/path/jenkins.war --plugin-file /file/path/plugins.txt --plugins delivery-pipeline-plugin:1.3.2 deployit-plugin
 ```

--- a/README.md
+++ b/README.md
@@ -112,17 +112,8 @@ java -jar plugin-management-cli/target/jenkins-plugin-manager-*.jar -p "workflow
 #### Proxy Support
 Proxy support is available using standard [Java networking system properties](https://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html) `http.proxyHost` and `http.proxyPort`. Note that this provides only basic NTLM support and you may need to use an authentication proxy like [CNTLM](https://sourceforge.net/projects/cntlm/).
 
-If you are behind a corporate proxy using a self-signed certificate you may wish to use the http variants of the default urls. The full list is given below for convenience.
-
 ```bash
-# Corporate environment example, using proxy and avoiding https, assume CNTLM running at http://myproxy.example.com:3128
-# In windows use set instead of export
-
-export JENKINS_INCREMENTALS_REPO_MIRROR=http://repo.jenkins-ci.org/incrementals
-export JENKINS_UC_EXPERIMENTAL=http://updates.jenkins.io/experimental/update-center.actual.json
-export JENKINS_UC=http://updates.jenkins.io/update-center.actual.json
-export JENKINS_PLUGIN_INFO=http://updates.jenkins.io/current/plugin-versions.json
-
+# Example using proxy system properties
 java -Dhttp.proxyPort=3128 -Dhttp.proxyHost=myproxy.example.com -jar plugin-management-cli/target/jenkins-plugin-manager-*.jar
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ java -jar plugin-management-cli/target/jenkins-plugin-manager-*.jar --war /file/
 * `--jenkins-update-center`: (optional) Sets the main update center filename, which can also be set via the JENKINS_UC environment variable. If a CLI option is entered, it will override what is set in the environment variable. If not set via CLI option or environment variable, will default to https://updates.jenkins.io/update-center.actual.json
 * `--jenkins-experimental-update-center`: (optional) Sets the experimental update center, which can also be set via the JENKINS_UC_EXPERIMENTAL environment variable. If a CLI option is entered, it will override what is set in the environment variable. If not set via CLI option or environment variable, will default to https://updates.jenkins.io/experimental/update-center.actual.json
 * `--jenkins-incrementals-repo-mirror`: (optional) Sets the incrementals repository mirror, which can also be set via the JENKINS_INCREMENTALS_REPO_MIRROR environment variable. If a CLI option is entered, it will override what is set in the environment variable. If not set via CLI option or environment variable, will default to https://repo.jenkins-ci.org/incrementals.
+* `--jenkins-plugin-info`: (optional) Sets the location of plugin information, which can also be set via the JENKINS_PLUGIN_INFO environment variable. If a CLI option is entered, it will override what is set in the environment variable. If not set via CLI option or environment variable, will default to https://updates.jenkins.io/current/plugin-versions.json.
 * `--version` or `-v`: (optional) Displays the plugin management tool version and exits.
 * `--no-download`: (optional) Set to true to avoid downloading plugins. By default it is set to false and plugins will be downloaded.
 * `--skip-failed-plugins`: (optional) Adds the option to skip plugins that fail to download - CAUTION should be used when passing this flag as it could leave
@@ -98,6 +99,24 @@ If a plugin to be downloaded from the incrementals repository is requested using
 ```
 java -jar plugin-management-cli/target/jenkins-plugin-manager-*.jar -p "workflow-support:incrementals;org.jenkins-ci.plugins.workflow;2.19-rc289.d09828a05a74"
 ```
+
+#### Proxy Support
+Proxy support is available using standard [Java networking system properties](https://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html) `http.proxyHost` and `http.proxyPort`. Note that this provides only basic NTLM support and you may need to use an authentication proxy like [CNTLM](https://sourceforge.net/projects/cntlm/).
+
+If you are behind a corporate proxy using a self-signed certificate you may wish to use the http variants of the default urls. The full list is given below for convenience.
+
+```bash
+# Corporate environment example, using proxy and avoiding https, assume CNTLM running at http://myproxy.example.com:3128
+# In windows use set instead of export
+
+export JENKINS_INCREMENTALS_REPO_MIRROR=http://repo.jenkins-ci.org/incrementals
+export JENKINS_UC_EXPERIMENTAL=http://updates.jenkins.io/experimental/update-center.actual.json
+export JENKINS_UC=http://updates.jenkins.io/update-center.actual.json
+export JENKINS_PLUGIN_INFO=http://updates.jenkins.io/current/plugin-versions.json
+
+java -Dhttp.proxyPort=3128 -Dhttp.proxyHost=myproxy.example.com -jar plugin-management-cli/target/jenkins-plugin-manager-*.jar
+```
+
 
 #### Other Information
 The plugin manager tries to use update center data to get the latest information about a plugin's dependencies. If this information is unavailable, it will use the dependency information from the downloaded plugin's MANIFEST.MF file. By default, the versions of the plugin dependencies are determined by the update center metadata or the plugin MANIFEST.MF file, but the user can specify other behavior using the `latest` or `latest-specified` options.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The expected format for plugins in the .txt file or entered through the `--plugi
 
 Use plugin artifact ID, without -plugin extension. If a plugin cannot be downloaded, -plugin will be appended to the name and download will be retried. This is for cases in which plugins don't follow the rules about artifact ID (i.e. docker plugin).
 
-The version and  download url are optional. By default, the latest version of the plugin will be downloaded. If both a version and an url are supplied, the version will not be used to determine the plugin download location and the library will attempt to download the plugin from the given url.
+The version and download url are optional. By default, the latest version of the plugin will be downloaded. If both a version and a url are supplied, the version will not be used to determine the plugin download location and the library will attempt to download the plugin from the given url.
 
 The following custom version specifiers can also be used:
 
@@ -83,7 +83,7 @@ Any root object other than `plugins` will be ignored by the plugin installation 
 
 
 #### Examples
-If an url is included, then a placeholder should be included for the version. Examples of plugin inputs:
+If a url is included, then a placeholder should be included for the version. Examples of plugin inputs:
 
 * `github-branch-source` - will download the latest version
 * `github-branch-source:latest` - will download the latest version
@@ -93,7 +93,7 @@ If an url is included, then a placeholder should be included for the version. Ex
 * `github-branch-source:https://updates.jenkins.io/2.121/latest/github-branch-source.hpi` - will treat the url like the version, which is not likely the behavior you want
 * `github-branch-source::https://updates.jenkins.io/2.121/latest/github-branch-source.hpi` - will download plugin from url
 
-If a plugin to be downloaded from the incrementals repository is requested using the -plugins option from the CLI, the plugin name should be enclosed in quotes, since the semi-colon is otherwise interpretted as the end of the command.
+If a plugin to be downloaded from the incrementals repository is requested using the -plugins option from the CLI, the plugin name should be enclosed in quotes, since the semi-colon is otherwise interpreted as the end of the command.
 
 ```
 java -jar plugin-management-cli/target/jenkins-plugin-manager-*.jar -p "workflow-support:incrementals;org.jenkins-ci.plugins.workflow;2.19-rc289.d09828a05a74"

--- a/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/CliOptions.java
+++ b/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/CliOptions.java
@@ -85,6 +85,13 @@ class CliOptions {
             handler = URLOptionHandler.class)
     private URL jenkinsIncrementalsRepoMirror;
 
+    @Option(name = "--jenkins-plugin-info",
+            usage = "Sets the location of plugin information; will override JENKINS_PLUGIN_INFO environment variable. " +
+                    "If not set via CLI option or environment variable, will default to " +
+                    Settings.DEFAULT_PLUGIN_INFO_LOCATION,
+            handler = URLOptionHandler.class)
+    private URL jenkinsPluginInfo;
+
     @Option(name = "--version", aliases = {"-v"}, usage = "View version and exit", handler = BooleanOptionHandler.class)
     private boolean showVersion;
 
@@ -125,6 +132,7 @@ class CliOptions {
                 .withJenkinsUc(getUpdateCenter())
                 .withJenkinsUcExperimental(getExperimentalUpdateCenter())
                 .withJenkinsIncrementalsRepoMirror(getIncrementalsMirror())
+                .withJenkinsPluginInfo(getPluginInfo())
                 .withJenkinsWar(getJenkinsWar())
                 .withShowWarnings(isShowWarnings())
                 .withShowAllWarnings(isShowAllWarnings())
@@ -340,6 +348,33 @@ class CliOptions {
                     jenkinsIncrementalsRepo);
         }
         return jenkinsIncrementalsRepo;
+    }
+
+    /**
+     * Determines the plugin information url string. If a value is set via CLI option, it will override a value
+     * set via environment variable. If neither are set, the default in the Settings class will be used.
+     *
+     * @return the plugin information url
+     */
+    private URL getPluginInfo() {
+        URL pluginInfo;
+        if (jenkinsPluginInfo != null) {
+            pluginInfo = jenkinsPluginInfo;
+            System.out.println("Using plugin info " + jenkinsPluginInfo + " specified with CLI option");
+        } else if (!StringUtils.isEmpty(System.getenv("JENKINS_PLUGIN_INFO"))) {
+            try {
+                pluginInfo = new URL(System.getenv("JENKINS_PLUGIN_INFO"));
+            } catch (MalformedURLException e) {
+                throw new RuntimeException(e);
+            }
+            System.out.println("Using plugin info " + pluginInfo +
+                    " from JENKINS_PLUGIN_INFO environment variable");
+        } else {
+            pluginInfo = Settings.DEFAULT_PLUGIN_INFO;
+            System.out.println("No CLI option or environment variable set for plugin info, using default of " +
+                    pluginInfo);
+        }
+        return pluginInfo;
     }
 
     /**

--- a/plugin-management-cli/src/test/java/io/jenkins/tools/pluginmanager/cli/CliOptionsTest.java
+++ b/plugin-management-cli/src/test/java/io/jenkins/tools/pluginmanager/cli/CliOptionsTest.java
@@ -83,6 +83,7 @@ public class CliOptionsTest {
         when(System.getenv("JENKINS_UC")).thenReturn("");
         when(System.getenv("JENKINS_UC_EXPERIMENTAL")).thenReturn("");
         when(System.getenv("JENKINS_INCREMENTALS_REPO_MIRROR")).thenReturn("");
+        when(System.getenv("JENKINS_PLUGIN_INFO")).thenReturn("");
 
         Config cfg = options.setup();
 
@@ -95,6 +96,7 @@ public class CliOptionsTest {
                 cfg.getJenkinsUcExperimental().toString());
         assertEquals(Settings.DEFAULT_INCREMENTALS_REPO_MIRROR_LOCATION,
                 cfg.getJenkinsIncrementalsRepoMirror().toString());
+        assertEquals(Settings.DEFAULT_PLUGIN_INFO_LOCATION, cfg.getJenkinsPluginInfo().toString());
     }
 
 
@@ -229,19 +231,23 @@ public class CliOptionsTest {
         String ucEnvVar = "https://updates.jenkins.io/env";
         String experimentalUcEnvVar = "https://updates.jenkins.io/experimental/env";
         String incrementalsEnvVar = "https://repo.jenkins-ci.org/incrementals/env";
+        String pluginInfoEnvVar = "https://updates.jenkins.io/current/plugin-versions/env";
 
         mockStatic(System.class);
         when(System.getenv("JENKINS_UC")).thenReturn(ucEnvVar);
         when(System.getenv("JENKINS_UC_EXPERIMENTAL")).thenReturn(experimentalUcEnvVar);
         when(System.getenv("JENKINS_INCREMENTALS_REPO_MIRROR")).thenReturn(incrementalsEnvVar);
+        when(System.getenv("JENKINS_PLUGIN_INFO")).thenReturn(pluginInfoEnvVar);
 
         String ucCli = "https://updates.jenkins.io/cli";
         String experiementalCli = "https://updates.jenkins.io/experimental/cli";
         String incrementalsCli = "https://repo.jenkins-ci.org/incrementals/cli";
+        String pluginInfoCli = "https://updates.jenkins.io/current/plugin-versions/cli";
 
         parser.parseArgument("--jenkins-update-center", ucCli,
                 "--jenkins-experimental-update-center", experiementalCli,
-                "--jenkins-incrementals-repo-mirror", incrementalsCli);
+                "--jenkins-incrementals-repo-mirror", incrementalsCli,
+                "--jenkins-plugin-info", pluginInfoCli);
 
         Config cfg = options.setup();
 
@@ -249,6 +255,7 @@ public class CliOptionsTest {
         assertEquals(ucCli, cfg.getJenkinsUc().toString());
         assertEquals(experiementalCli, cfg.getJenkinsUcExperimental().toString());
         assertEquals(incrementalsCli, cfg.getJenkinsIncrementalsRepoMirror().toString());
+        assertEquals(pluginInfoCli, cfg.getJenkinsPluginInfo().toString());
     }
 
     @Test
@@ -256,16 +263,19 @@ public class CliOptionsTest {
         String ucEnvVar = "https://updates.jenkins.io/env";
         String experimentalUcEnvVar = "https://updates.jenkins.io/experimental/env";
         String incrementalsEnvVar = "https://repo.jenkins-ci.org/incrementals/env";
+        String pluginInfoEnvVar = "https://updates.jenkins.io/current/plugin-versions/env";
 
         mockStatic(System.class);
         when(System.getenv("JENKINS_UC")).thenReturn(ucEnvVar);
         when(System.getenv("JENKINS_UC_EXPERIMENTAL")).thenReturn(experimentalUcEnvVar);
         when(System.getenv("JENKINS_INCREMENTALS_REPO_MIRROR")).thenReturn(incrementalsEnvVar);
+        when(System.getenv("JENKINS_PLUGIN_INFO")).thenReturn(pluginInfoEnvVar);
 
         Config cfg = options.setup();
         assertEquals(ucEnvVar, cfg.getJenkinsUc().toString());
         assertEquals(experimentalUcEnvVar, cfg.getJenkinsUcExperimental().toString());
         assertEquals(incrementalsEnvVar, cfg.getJenkinsIncrementalsRepoMirror().toString());
+        assertEquals(pluginInfoEnvVar, cfg.getJenkinsPluginInfo().toString());
     }
 
     @Test

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Config.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Config.java
@@ -28,6 +28,7 @@ public class Config {
     private URL jenkinsUc;
     private URL jenkinsUcExperimental;
     private URL jenkinsIncrementalsRepoMirror;
+    private URL jenkinsPluginInfo;
     private boolean doDownload;
     private boolean useLatestSpecified;
     private boolean useLatestAll;
@@ -45,6 +46,7 @@ public class Config {
             URL jenkinsUc,
             URL jenkinsUcExperimental,
             URL jenkinsIncrementalsRepoMirror,
+            URL jenkinsPluginInfo,
             boolean doDownload,
             boolean useLatestSpecified,
             boolean useLatestAll,
@@ -61,6 +63,7 @@ public class Config {
         this.jenkinsUc = jenkinsUc;
         this.jenkinsUcExperimental = jenkinsUcExperimental;
         this.jenkinsIncrementalsRepoMirror = jenkinsIncrementalsRepoMirror;
+        this.jenkinsPluginInfo = jenkinsPluginInfo;
         this.doDownload = doDownload;
         this.useLatestSpecified = useLatestSpecified;
         this.useLatestAll = useLatestAll;
@@ -112,6 +115,10 @@ public class Config {
         return jenkinsIncrementalsRepoMirror;
     }
 
+    public URL getJenkinsPluginInfo() {
+        return jenkinsPluginInfo;
+    }
+
     public boolean doDownload() {
         return doDownload;
     }
@@ -142,6 +149,7 @@ public class Config {
         private URL jenkinsUc = Settings.DEFAULT_UPDATE_CENTER;
         private URL jenkinsUcExperimental = Settings.DEFAULT_EXPERIMENTAL_UPDATE_CENTER;
         private URL jenkinsIncrementalsRepoMirror = Settings.DEFAULT_INCREMENTALS_REPO_MIRROR;
+        private URL jenkinsPluginInfo = Settings.DEFAULT_PLUGIN_INFO;
         private boolean doDownload;
         private boolean useLatestSpecified;
         private boolean useLatestAll;
@@ -205,6 +213,11 @@ public class Config {
             return this;
         }
 
+        public Builder withJenkinsPluginInfo(URL jenkinsPluginInfo) {
+            this.jenkinsPluginInfo = jenkinsPluginInfo;
+            return this;
+        }
+
         public Builder withDoDownload(boolean doDownload) {
             this.doDownload = doDownload;
             return this;
@@ -238,6 +251,7 @@ public class Config {
                     jenkinsUc,
                     jenkinsUcExperimental,
                     jenkinsIncrementalsRepoMirror,
+                    jenkinsPluginInfo,
                     doDownload,
                     useLatestSpecified,
                     useLatestAll,

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Settings.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Settings.java
@@ -15,6 +15,7 @@ public class Settings {
     public static final String DEFAULT_EXPERIMENTAL_UPDATE_CENTER_LOCATION = "https://updates.jenkins.io/experimental" + DEFAULT_UPDATE_CENTER_FILENAME;
     public static final URL DEFAULT_INCREMENTALS_REPO_MIRROR;
     public static final String DEFAULT_INCREMENTALS_REPO_MIRROR_LOCATION = "https://repo.jenkins-ci.org/incrementals";
+    public static final URL DEFAULT_PLUGIN_INFO;
     public static final String DEFAULT_PLUGIN_INFO_LOCATION = "https://updates.jenkins.io/current/plugin-versions.json";
     public static final Path DEFAULT_CACHE_PATH;
 
@@ -35,6 +36,7 @@ public class Settings {
             DEFAULT_UPDATE_CENTER = new URL(DEFAULT_UPDATE_CENTER_LOCATION);
             DEFAULT_EXPERIMENTAL_UPDATE_CENTER = new URL(DEFAULT_EXPERIMENTAL_UPDATE_CENTER_LOCATION);
             DEFAULT_INCREMENTALS_REPO_MIRROR = new URL(DEFAULT_INCREMENTALS_REPO_MIRROR_LOCATION);
+            DEFAULT_PLUGIN_INFO = new URL(DEFAULT_PLUGIN_INFO_LOCATION);
         } catch (MalformedURLException e) {
             throw new RuntimeException(e);
         }

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -591,7 +591,7 @@ public class PluginManager {
         latestUcJson = getJson(stringToUrlQuietly(jenkinsUcLatest), "update-center");
         latestPlugins = latestUcJson.getJSONObject("plugins");
         experimentalUcJson = getJson(cfg.getJenkinsUcExperimental(), "experimental-update-center");
-        pluginInfoJson = getJson(stringToUrlQuietly(Settings.DEFAULT_PLUGIN_INFO_LOCATION), "plugin-versions");
+        pluginInfoJson = getJson(cfg.getJenkinsPluginInfo(), "plugin-versions");
     }
 
     /**


### PR DESCRIPTION
Thanks for the tool. We too have created something similar and I would like to delete ours and use this instead. I have only just started experimenting, this PR contains what I needed in terms of code patches and some documentation that would have shaved hours off the time it took me to work this all out.

In summary:

* Allow hard-coded URL `DEFAULT_PLUGIN_INFO_LOCATION` to be overridden via cli and env like the other URLs.
* Add documentation, tips, examples for downloading plugins thru a corporate proxy, including NTLM authentication and avoiding https.
* Directions to download pre-built jar instead of building (which is difficult in a corporate environment due to the use of non-standard maven repo @ repo.jenkins-ci.org/public/
* Fixed a few typos as I went.