### PR TITLE
Force versions to be explicit strings in YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ plugins:
       version: latest
   - artifactId: job-import-plugin
     source:
-      version: 2.1
+      version: "2.1"
   - artifactId: docker
   - artifactId: cloudbees-bitbucket-branch-source
     source:
@@ -89,7 +89,7 @@ tool:
   ...
 ```
 
-Any root object other than `plugins` will be ignored by the plugin installation manager tool. As with the plugins.txt file, version and url are optional, and if no version is entered, the latest version is the default. If a groupId is entered, the tool will try to download the plugin from the incrementals repository.
+Any root object other than `plugins` will be ignored by the plugin installation manager tool. As with the plugins.txt file, version and url are optional, and if no version is entered, the latest version is the default. You must ensure that versions are explicit strings in yaml, if in doubt put the version in quotes. If a groupId is entered, the tool will try to download the plugin from the incrementals repository.
 
 
 #### Examples

--- a/plugin-management-cli/src/test/resources/plugins.yaml
+++ b/plugin-management-cli/src/test/resources/plugins.yaml
@@ -6,7 +6,7 @@ plugins:
       version: latest
   - artifactId: job-import-plugin
     source:
-      version: 2.1
+      version: "2.1"
   - artifactId: docker
   - artifactId: cloudbees-bitbucket-branch-source
     source:

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/util/PluginListParser.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/util/PluginListParser.java
@@ -83,7 +83,6 @@ public class PluginListParser {
                     Object groupIdObject = pluginInfo.get("groupId");
                     String groupId = groupIdObject == null ? null : groupIdObject.toString();
                     Map pluginSource = (Map) pluginInfo.get("source");
-                    String incrementalsVersion = null;
                     Plugin plugin;
                     if (pluginSource == null && !StringUtils.isEmpty(groupId)) {
                         throw new PluginInputException("Version must be input for " + name);
@@ -94,7 +93,16 @@ public class PluginListParser {
                         if (!StringUtils.isEmpty(groupId) && versionObject == null) {
                             throw new PluginInputException("Version must be input for " + name);
                         }
-                        String version = versionObject == null ? "latest" : versionObject.toString();
+                        String version;
+                        if (versionObject != null) {
+                            if (versionObject instanceof String) {
+                                version = (String)versionObject;
+                            } else {
+                                throw new PluginInputException("Version must be in quotes for " + name);
+                            }
+                        } else {
+                            version = "latest";
+                        }
                         Object urlObject = pluginSource.get("url");
                         String url;
                         if (urlObject != null && isURL(urlObject.toString())) {

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/util/PluginListParserTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/util/PluginListParserTest.java
@@ -139,6 +139,12 @@ public class PluginListParserTest {
         List<Plugin> pluginsFromYamlFile = pluginList.parsePluginYamlFile(pluginYmlFile);
     }
 
+    @Test(expected = PluginInputException.class)
+    public void badFormatYamlVersionAsNumber() throws URISyntaxException {
+        File pluginYmlFile = new File(this.getClass().getResource("PluginListParserTest/badformat4.yaml").toURI());
+        List<Plugin> pluginsFromYamlFile = pluginList.parsePluginYamlFile(pluginYmlFile);
+    }
+
     @Test
     public void fileExistsTest() throws URISyntaxException {
         assertEquals(false, pluginList.fileExists(null));

--- a/plugin-management-library/src/test/resources/io/jenkins/tools/pluginmanager/util/PluginListParserTest/badformat1.yaml
+++ b/plugin-management-library/src/test/resources/io/jenkins/tools/pluginmanager/util/PluginListParserTest/badformat1.yaml
@@ -1,7 +1,7 @@
 plugins:
   - artifactId: job-import-plugin
     source:
-      version: 2.1
+      version: "2.1"
   - artifactId:
     source:
       version: latest

--- a/plugin-management-library/src/test/resources/io/jenkins/tools/pluginmanager/util/PluginListParserTest/badformat4.yaml
+++ b/plugin-management-library/src/test/resources/io/jenkins/tools/pluginmanager/util/PluginListParserTest/badformat4.yaml
@@ -1,0 +1,6 @@
+jenkins:
+  systemMessage: "Testing"
+plugins:
+  - artifactId: build-timeout
+    source:
+      version: 1.20

--- a/plugin-management-library/src/test/resources/io/jenkins/tools/pluginmanager/util/PluginListParserTest/plugins.yaml
+++ b/plugin-management-library/src/test/resources/io/jenkins/tools/pluginmanager/util/PluginListParserTest/plugins.yaml
@@ -6,7 +6,7 @@ plugins:
       version: latest
   - artifactId: job-import-plugin
     source:
-      version: 2.1
+      version: "2.1"
   - artifactId: docker
   - artifactId: cloudbees-bitbucket-branch-source
     source:


### PR DESCRIPTION
Some plugin versions will be interpreted by the YAML parser as a number (double). 

This could cause some incredibly difficult-to-detect bugs.

Example:

```yaml
# This will incorrectly but happily download version 1.2 of build-timeout
plugins:
  - artifactId: build-timeout
    source:
      version: 1.20
```

```yaml
# This will correctly download version 1.20 of build-timeout
plugins:
  - artifactId: build-timeout
    source:
      version: "1.20"
```

The proposed PR protects the user from making this mistake by refusing to accept versions that have been interpreted as numbers. Due to the prevalence of semver this likely will not affect most plugin definitions.
