### PR TITLE
Use System Lambda instead of System Rules

### DIFF
--- a/plugin-management-library/pom.xml
+++ b/plugin-management-library/pom.xml
@@ -46,8 +46,8 @@
         </dependency>
         <dependency>
             <groupId>com.github.stefanbirkner</groupId>
-            <artifactId>system-rules</artifactId>
-            <version>1.19.0</version>
+            <artifactId>system-lambda</artifactId>
+            <version>1.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerIntegrationTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerIntegrationTest.java
@@ -18,11 +18,10 @@ import org.apache.commons.io.IOUtils;
 import org.json.JSONObject;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.rules.TemporaryFolder;
 
+import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemOut;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertEquals;
@@ -42,9 +41,6 @@ public class PluginManagerIntegrationTest {
     public static File jenkinsWar;
     public static File cacheDir;
     public static File pluginsDir;
-
-    @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog();
 
     // TODO: Convert to a rule
     public interface Configurator {
@@ -114,15 +110,16 @@ public class PluginManagerIntegrationTest {
 
     // https://github.com/jenkinsci/plugin-installation-manager-tool/issues/101
     @Test
-    public void showAvailableUpdates_shouldNotFailOnUIThemes() throws IOException {
+    public void showAvailableUpdates_shouldNotFailOnUIThemes() throws Exception {
         Plugin pluginDockerCommons = new Plugin("docker-commons", "1.16", null, null);
         Plugin pluginYAD = new Plugin("yet-another-docker-plugin", "0.2.0", null, null);
         Plugin pluginIconShim = new Plugin("icon-shim", "2.0.3", null, null);
         PluginManager pluginManager = initPluginManager(
                 configBuilder -> configBuilder.withPlugins(Arrays.asList(pluginDockerCommons, pluginIconShim, pluginYAD)));
 
-        pluginManager.start(false);
-        assertThat(systemOutRule.getLog(), not(containsString("uithemes")));
+        String output = tapSystemOut(
+                () -> pluginManager.start(false));
+        assertThat(output, not(containsString("uithemes")));
     }
 
     @Test


### PR DESCRIPTION
System Lambda allows to catch the output of exactly one statement
instead of the whole test method. This makes the test more precise. In
addition it does not depend on JUnit 4 so that it is easier to change
the testing framework later (e.g. use JUnit Jupiter).