### PR TITLE
Fix test "checkVersionCompatibilityPassTest"

### DIFF
--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
@@ -599,16 +599,14 @@ public class PluginManagerTest {
     public void checkVersionCompatibilityPassTest() {
         pm.setJenkinsVersion(new VersionNumber("2.121.2"));
 
-        ByteArrayOutputStream output = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(output));
-
         Plugin plugin1 = new Plugin("plugin1", "1.0", null, null);
         plugin1.setJenkinsVersion("2.121.2");
 
         Plugin plugin2 = new Plugin("plugin2", "2.1.1", null, null);
         plugin2.setJenkinsVersion("1.609.3");
 
-        assertEquals("", output.toString());
+        //check passes if no exception is thrown
+        pm.checkVersionCompatibility(Arrays.asList(plugin1, plugin2));
     }
 
     @Test


### PR DESCRIPTION
- Call the method under test.
- Don't replace System.out because the method under test does not write
  to System.out.