### PR TITLE
Tidy up test "checkVersionCompatibilityNullTest"

### DIFF
--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
@@ -566,19 +566,14 @@ public class PluginManagerTest {
     public void checkVersionCompatibilityNullTest() {
         pm.setJenkinsVersion(null);
 
-        ByteArrayOutputStream output = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(output));
-
         Plugin plugin1 = new Plugin("plugin1", "1.0", null, null);
         plugin1.setJenkinsVersion("2.121.2");
 
         Plugin plugin2 = new Plugin("plugin2", "2.1.1", null, null);
         plugin2.setJenkinsVersion("1.609.3");
 
-        List<Plugin> pluginsToDownload = new ArrayList<>(Arrays.asList(plugin1, plugin2));
-        pm.checkVersionCompatibility(pluginsToDownload);
-
-        assertEquals("", output.toString());
+        //check passes if no exception is thrown
+        pm.checkVersionCompatibility(Arrays.asList(plugin1, plugin2));
     }
 
     @Test(expected = VersionCompatibilityException.class)


### PR DESCRIPTION
- Remove redundant wrapping of plugin list with ArrayList.
- Don't replace System.out because the method under test does not write
  to System.out.
- Explain why there is no assertion.