### PR TITLE
Remove Comparable interface from Plugin

### DIFF
--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/Plugin.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/Plugin.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 
-public class Plugin implements Comparable<Plugin> {
+public class Plugin {
     private String name;
     private String originalName;
     private VersionNumber version;
@@ -157,17 +157,6 @@ public class Plugin implements Comparable<Plugin> {
             return name + " " + version;
         }
         return name + " " + version + " " + url;
-    }
-
-    @Override
-    public int compareTo(Plugin p) {
-        if (this.equals(p)) {
-            return 0;
-        } else if (this.getName().equals(p.getName())) {
-            return this.getVersion().compareTo(p.getVersion());
-        } else {
-            return this.getName().compareTo(p.getName());
-        }
     }
 
     @Override

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -60,6 +60,7 @@ import static io.jenkins.tools.pluginmanager.util.PluginManagerUtils.dirName;
 import static io.jenkins.tools.pluginmanager.util.PluginManagerUtils.insertPathPreservingFilename;
 import static io.jenkins.tools.pluginmanager.util.PluginManagerUtils.removePath;
 import static io.jenkins.tools.pluginmanager.util.PluginManagerUtils.removePossibleWrapperText;
+import static java.util.Comparator.comparing;
 
 public class PluginManager {
     private List<Plugin> failedPlugins;
@@ -261,7 +262,8 @@ public class PluginManager {
      */
     public void logPlugins(String description, List<Plugin> plugins) {
         System.out.println("\n" + description);
-        plugins.stream().sorted()
+        plugins.stream()
+                .sorted(comparing(Plugin::getName).thenComparing(Plugin::getVersion))
                 .forEach(System.out::println);
     }
 


### PR DESCRIPTION
IMO there is no canonical order for sorting plugins. There is currently
only one part of the code that sorts plugin. By defining the sorting
there it is much clearer what happens because the sorting is explicit.