### PR TITLE
Use AssertJ for assertions

### DIFF
--- a/plugin-management-cli/pom.xml
+++ b/plugin-management-cli/pom.xml
@@ -39,6 +39,11 @@
             <version>1.0.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/plugin-management-cli/src/test/java/io/jenkins/tools/pluginmanager/cli/CliOptionsTest.java
+++ b/plugin-management-cli/src/test/java/io/jenkins/tools/pluginmanager/cli/CliOptionsTest.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
@@ -25,8 +24,8 @@ import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironment
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static org.apache.commons.io.IOUtils.toInputStream;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
@@ -76,16 +75,14 @@ public class CliOptionsTest {
             .execute(() -> {
                 Config cfg = options.setup();
 
-                assertEquals(Settings.DEFAULT_PLUGIN_DIR_LOCATION, cfg.getPluginDir().toString());
-                assertEquals(Settings.DEFAULT_WAR, cfg.getJenkinsWar());
-                assertEquals(false, cfg.isShowAllWarnings());
-                assertEquals(false, cfg.isShowWarnings());
-                assertEquals(Settings.DEFAULT_UPDATE_CENTER_LOCATION, cfg.getJenkinsUc().toString());
-                assertEquals(Settings.DEFAULT_EXPERIMENTAL_UPDATE_CENTER_LOCATION,
-                        cfg.getJenkinsUcExperimental().toString());
-                assertEquals(Settings.DEFAULT_INCREMENTALS_REPO_MIRROR_LOCATION,
-                        cfg.getJenkinsIncrementalsRepoMirror().toString());
-                assertEquals(Settings.DEFAULT_PLUGIN_INFO_LOCATION, cfg.getJenkinsPluginInfo().toString());
+                assertThat(cfg.getPluginDir()).hasToString(Settings.DEFAULT_PLUGIN_DIR_LOCATION);
+                assertThat(cfg.getJenkinsWar()).isEqualTo(Settings.DEFAULT_WAR);
+                assertThat(cfg.isShowAllWarnings()).isFalse();
+                assertThat(cfg.isShowWarnings()).isFalse();
+                assertThat(cfg.getJenkinsUc()).hasToString(Settings.DEFAULT_UPDATE_CENTER_LOCATION);
+                assertThat(cfg.getJenkinsUcExperimental()).hasToString(Settings.DEFAULT_EXPERIMENTAL_UPDATE_CENTER_LOCATION);
+                assertThat(cfg.getJenkinsIncrementalsRepoMirror()).hasToString(Settings.DEFAULT_INCREMENTALS_REPO_MIRROR_LOCATION);
+                assertThat(cfg.getJenkinsPluginInfo()).hasToString(Settings.DEFAULT_PLUGIN_INFO_LOCATION);
             });
     }
 
@@ -107,10 +104,9 @@ public class CliOptionsTest {
 
         Config cfg = options.setup();
 
-        assertEquals(pluginDir, cfg.getPluginDir());
-        assertEquals(jenkinsWar.toString(), cfg.getJenkinsWar());
-        assertEquals(1, cfg.getPlugins().size());
-        assertEquals(displayUrlPlugin.toString(), cfg.getPlugins().get(0).toString());
+        assertThat(cfg.getPluginDir()).isEqualTo(pluginDir);
+        assertThat(cfg.getJenkinsWar()).isEqualTo(jenkinsWar.toString());
+        assertThat(cfg.getPlugins()).containsExactly(displayUrlPlugin);
     }
 
     @Test
@@ -163,7 +159,8 @@ public class CliOptionsTest {
 
         parser.parseArgument("--plugin-file", pluginFile.toString());
 
-        assertThrows(PluginInputException.class, options::setup);
+        assertThatThrownBy(options::setup)
+                .isInstanceOf(PluginInputException.class);
     }
 
     @Test
@@ -173,7 +170,7 @@ public class CliOptionsTest {
         parser.parseArgument("--war", jenkinsWar);
 
         Config cfg = options.setup();
-        assertEquals(jenkinsWar, cfg.getJenkinsWar());
+        assertThat(cfg.getJenkinsWar()).isEqualTo(jenkinsWar);
     }
 
     @Test
@@ -183,7 +180,7 @@ public class CliOptionsTest {
         parser.parseArgument("--plugin-download-directory", pluginDir);
 
         Config cfg = options.setup();
-        assertEquals(pluginDir, cfg.getPluginDir().toString());
+        assertThat(cfg.getPluginDir()).hasToString(pluginDir);
     }
 
     @Test
@@ -211,10 +208,10 @@ public class CliOptionsTest {
                 Config cfg = options.setup();
 
                 // Cli options should override environment variables
-                assertEquals(ucCli, cfg.getJenkinsUc().toString());
-                assertEquals(experiementalCli, cfg.getJenkinsUcExperimental().toString());
-                assertEquals(incrementalsCli, cfg.getJenkinsIncrementalsRepoMirror().toString());
-                assertEquals(pluginInfoCli, cfg.getJenkinsPluginInfo().toString());
+                assertThat(cfg.getJenkinsUc()).hasToString(ucCli);
+                assertThat(cfg.getJenkinsUcExperimental()).hasToString(experiementalCli);
+                assertThat(cfg.getJenkinsIncrementalsRepoMirror()).hasToString(incrementalsCli);
+                assertThat(cfg.getJenkinsPluginInfo()).hasToString(pluginInfoCli);
             });
     }
 
@@ -231,10 +228,10 @@ public class CliOptionsTest {
             .and("JENKINS_PLUGIN_INFO", pluginInfoEnvVar)
             .execute(() -> {
                 Config cfg = options.setup();
-                assertEquals(ucEnvVar, cfg.getJenkinsUc().toString());
-                assertEquals(experimentalUcEnvVar, cfg.getJenkinsUcExperimental().toString());
-                assertEquals(incrementalsEnvVar, cfg.getJenkinsIncrementalsRepoMirror().toString());
-                assertEquals(pluginInfoEnvVar, cfg.getJenkinsPluginInfo().toString());
+                assertThat(cfg.getJenkinsUc()).hasToString(ucEnvVar);
+                assertThat(cfg.getJenkinsUcExperimental()).hasToString(experimentalUcEnvVar);
+                assertThat(cfg.getJenkinsIncrementalsRepoMirror()).hasToString(incrementalsEnvVar);
+                assertThat(cfg.getJenkinsPluginInfo()).hasToString(pluginInfoEnvVar);
             });
     }
 
@@ -242,8 +239,8 @@ public class CliOptionsTest {
     public void setupSecurityWarningsTest() throws CmdLineException {
         parser.parseArgument("--view-all-security-warnings", "--view-security-warnings");
         Config cfg = options.setup();
-        assertEquals(true, cfg.isShowAllWarnings());
-        assertEquals(true, cfg.isShowWarnings());
+        assertThat(cfg.isShowAllWarnings()).isTrue();
+        assertThat(cfg.isShowWarnings()).isTrue();
     }
 
     @Test
@@ -258,11 +255,11 @@ public class CliOptionsTest {
         parserWithVersion.parseArgument("--version");
 
         String output = tapSystemOutNormalized(optionsWithVersion::showVersion);
-        assertEquals("testVersion\n", output);
+        assertThat(output).isEqualTo("testVersion\n");
 
         parserWithVersion.parseArgument("-v");
         String aliasOutput = tapSystemOutNormalized(optionsWithVersion::showVersion);
-        assertEquals("testVersion\n", aliasOutput);
+        assertThat(aliasOutput).isEqualTo("testVersion\n");
     }
 
     @Test
@@ -271,60 +268,62 @@ public class CliOptionsTest {
         parser.parseArgument("--version");
         doReturn(null).when(cliOptionsSpy).getPropertiesInputStream(any(String.class));
 
-        assertThrows(VersionNotFoundException.class, cliOptionsSpy::showVersion);
+        assertThatThrownBy(cliOptionsSpy::showVersion)
+                .isInstanceOf(VersionNotFoundException.class);
     }
 
     @Test
     public void noDownloadTest() throws CmdLineException {
         parser.parseArgument("--no-download");
         Config cfg = options.setup();
-        assertEquals(false, cfg.doDownload());
+        assertThat(cfg.doDownload()).isFalse();
     }
 
     @Test
     public void downloadTest() throws CmdLineException {
         parser.parseArgument();
         Config cfg = options.setup();
-        assertEquals(true, cfg.doDownload());
+        assertThat(cfg.doDownload()).isTrue();
     }
 
     @Test
     public void useLatestSpecifiedTest() throws CmdLineException {
         parser.parseArgument("--latest-specified");
         Config cfg = options.setup();
-        assertEquals(true, cfg.isUseLatestSpecified());
+        assertThat(cfg.isUseLatestSpecified()).isTrue();
     }
 
     @Test
     public void useNotLatestSpecifiedTest() throws CmdLineException {
         parser.parseArgument();
         Config cfg = options.setup();
-        assertEquals(false, cfg.isUseLatestSpecified());
+        assertThat(cfg.isUseLatestSpecified()).isFalse();
     }
 
     @Test
     public void useLatestTest() throws CmdLineException {
         parser.parseArgument("--latest");
         Config cfg = options.setup();
-        assertEquals(true, cfg.isUseLatestAll());
+        assertThat(cfg.isUseLatestAll()).isTrue();
     }
 
     @Test
     public void useNotLatestTest() throws CmdLineException {
         parser.parseArgument();
         Config cfg = options.setup();
-        assertEquals(false, cfg.isUseLatestAll());
+        assertThat(cfg.isUseLatestAll()).isFalse();
     }
 
     @Test
     public void useLatestSpecifiedAndLatestAllTest() throws CmdLineException {
         parser.parseArgument("--latest", "--latest-specified");
 
-        assertThrows(PluginDependencyStrategyException.class, options::setup);
+        assertThatThrownBy(options::setup)
+            .isInstanceOf(PluginDependencyStrategyException.class);
     }
 
-    private void assertConfigHasPlugins(Config cfg, List<Plugin> requestedPlugins) {
-        List<Plugin> plugins = cfg.getPlugins();
-        assertEquals(new HashSet<>(requestedPlugins), new HashSet<>(plugins));
+    private void assertConfigHasPlugins(Config cfg, List<Plugin> expectedPlugins) {
+        Plugin[] expectedPluginsAsArray = expectedPlugins.toArray(new Plugin[0]);
+        assertThat(cfg.getPlugins()).containsExactlyInAnyOrder(expectedPluginsAsArray);
     }
 }

--- a/plugin-management-cli/src/test/java/io/jenkins/tools/pluginmanager/cli/URLValidatorTest.java
+++ b/plugin-management-cli/src/test/java/io/jenkins/tools/pluginmanager/cli/URLValidatorTest.java
@@ -6,7 +6,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(Parameterized.class)
 public class URLValidatorTest {
@@ -28,6 +28,6 @@ public class URLValidatorTest {
 
     @Test
     public void validURLs() {
-        assertTrue(PluginListParser.isURL(url));
+        assertThat(PluginListParser.isURL(url)).isTrue();
     }
 }

--- a/plugin-management-library/pom.xml
+++ b/plugin-management-library/pom.xml
@@ -51,6 +51,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
             <version>1.24</version>

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerIntegrationTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerIntegrationTest.java
@@ -10,8 +10,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import org.apache.commons.io.IOUtils;
@@ -22,10 +22,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemOut;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link PluginManager} which operate with real data.
@@ -119,7 +116,7 @@ public class PluginManagerIntegrationTest {
 
         String output = tapSystemOut(
                 () -> pluginManager.start(false));
-        assertThat(output, not(containsString("uithemes")));
+        assertThat(output).doesNotContain("uithemes");
     }
 
     @Test
@@ -144,18 +141,16 @@ public class PluginManagerIntegrationTest {
         Plugin replacedSecond2 = new Plugin("replaced2", "3.2", null, null).withoutDependencies();
         plugin3.setDependencies(Arrays.asList(plugin3Dependency1, replacedSecond2));
 
-        // Expected
-        List<Plugin> expectedPlugins = new ArrayList<>(Arrays.asList(plugin1, plugin1Dependency1, plugin1Dependency2,
-                plugin2Dependency1, plugin2, plugin2Dependency2, plugin3, plugin3Dependency1, replaced2, replacedSecond2));
-        Collections.sort(expectedPlugins);
-
         // Actual
         List<Plugin> requestedPlugins = new ArrayList<>(Arrays.asList(plugin1, plugin2, plugin3, replaced));
         PluginManager pluginManager = initPluginManager(
             configBuilder -> configBuilder.withPlugins(requestedPlugins));
-        List<Plugin> pluginsAndDependencies = new ArrayList<>(pluginManager.findPluginsAndDependencies(requestedPlugins).values());
-        Collections.sort(pluginsAndDependencies);
+        Map<String, Plugin> pluginsAndDependencies = pluginManager.findPluginsAndDependencies(requestedPlugins);
 
-        assertEquals(expectedPlugins, pluginsAndDependencies);
+        assertThat(pluginsAndDependencies.values()).containsExactlyInAnyOrder(
+                plugin1, plugin1Dependency1, plugin1Dependency2,
+                plugin2Dependency1, plugin2, plugin2Dependency2,
+                plugin3, plugin3Dependency1,
+                replaced2, replacedSecond2);
     }
 }

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
@@ -12,12 +12,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
@@ -51,12 +48,8 @@ import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemOutNor
 import static io.jenkins.tools.pluginmanager.util.PluginManagerUtils.dirName;
 import static java.nio.file.Files.createDirectory;
 import static java.util.Collections.singletonList;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyMap;
@@ -147,7 +140,8 @@ public class PluginManagerTest {
 
         PluginManager pluginManager = new PluginManager(config);
 
-        assertThrows(DirectoryCreationException.class, pluginManager::start);
+        assertThatThrownBy(pluginManager::start)
+                .isInstanceOf(DirectoryCreationException.class);
     }
 
     @Test
@@ -172,13 +166,20 @@ public class PluginManagerTest {
 
         Map<String, Plugin> effectivePlugins = pm.findEffectivePlugins(requestedPlugins);
 
-        assertEquals("1.3", effectivePlugins.get("git").getVersion().toString());
-        assertEquals("2.2.3", effectivePlugins.get("scm-api").getVersion().toString());
-        assertEquals("1.24", effectivePlugins.get("aws-credentials").getVersion().toString());
-        assertEquals("1.3.3", effectivePlugins.get("p4").getVersion().toString());
-        assertEquals("1.26", effectivePlugins.get("script-security").getVersion().toString());
-        assertEquals("2.1.11", effectivePlugins.get("credentials").getVersion().toString());
-        assertEquals("1.0.1", effectivePlugins.get("ace-editor").getVersion().toString());
+        assertThat(effectivePlugins.get("git").getVersion())
+                .hasToString("1.3");
+        assertThat(effectivePlugins.get("scm-api").getVersion())
+                .hasToString("2.2.3");
+        assertThat(effectivePlugins.get("aws-credentials").getVersion())
+                .hasToString("1.24");
+        assertThat(effectivePlugins.get("p4").getVersion())
+                .hasToString("1.3.3");
+        assertThat(effectivePlugins.get("script-security").getVersion())
+                .hasToString("1.26");
+        assertThat(effectivePlugins.get("credentials").getVersion())
+                .hasToString("2.1.11");
+        assertThat(effectivePlugins.get("ace-editor").getVersion())
+                .hasToString("1.0.1");
     }
 
     @Test
@@ -194,7 +195,7 @@ public class PluginManagerTest {
         String output = tapSystemOutNormalized(
                 pluginManager::listPlugins);
 
-        assertEquals("", output);
+        assertThat(output).isEmpty();
     }
 
 
@@ -251,37 +252,35 @@ public class PluginManagerTest {
                 Arrays.asList(plugin1, plugin2, dependency1, dependency2));
         pluginManager.setEffectivePlugins(effectivePlugins);
 
-        String expectedOutput =
-                "\nInstalled plugins:\n" +
-                "installed1 1.0\n" +
-                "installed2 2.0\n" +
-                "\nBundled plugins:\n" +
-                "bundled1 1.0\n" +
-                "bundled2 2.0\n" +
-                "\nSet of all requested plugins:\n" +
-                "dependency1 1.0.0\n" +
-                "dependency2 1.0.0\n" +
-                "plugin1 1.0\n" +
-                "plugin2 2.0\n" +
-                "\nSet of all requested plugins that will be downloaded:\n" +
-                "dependency1 1.0.0\n" +
-                "dependency2 1.0.0\n" +
-                "plugin1 1.0\n" +
-                "plugin2 2.0\n" +
-                "\nSet of all existing plugins and plugins that will be downloaded:\n" +
-                "bundled1 1.0\n" +
-                "bundled2 2.0\n" +
-                "dependency1 1.0.0\n" +
-                "dependency2 1.0.0\n" +
-                "installed1 1.0\n" +
-                "installed2 2.0\n" +
-                "plugin1 1.0\n" +
-                "plugin2 2.0\n";
-
         String output = tapSystemOutNormalized(
                 pluginManager::listPlugins);
 
-        assertEquals(expectedOutput, output);
+        assertThat(output).isEqualTo(
+                "\nInstalled plugins:\n" +
+                        "installed1 1.0\n" +
+                        "installed2 2.0\n" +
+                        "\nBundled plugins:\n" +
+                        "bundled1 1.0\n" +
+                        "bundled2 2.0\n" +
+                        "\nSet of all requested plugins:\n" +
+                        "dependency1 1.0.0\n" +
+                        "dependency2 1.0.0\n" +
+                        "plugin1 1.0\n" +
+                        "plugin2 2.0\n" +
+                        "\nSet of all requested plugins that will be downloaded:\n" +
+                        "dependency1 1.0.0\n" +
+                        "dependency2 1.0.0\n" +
+                        "plugin1 1.0\n" +
+                        "plugin2 2.0\n" +
+                        "\nSet of all existing plugins and plugins that will be downloaded:\n" +
+                        "bundled1 1.0\n" +
+                        "bundled2 2.0\n" +
+                        "dependency1 1.0.0\n" +
+                        "dependency2 1.0.0\n" +
+                        "installed1 1.0\n" +
+                        "installed2 2.0\n" +
+                        "plugin1 1.0\n" +
+                        "plugin2 2.0\n");
     }
 
     @Test
@@ -352,13 +351,13 @@ public class PluginManagerTest {
         Plugin gitPlugin = new Plugin("structs", "1.17", null, null);
         JSONArray gitJson = pm.getPluginDependencyJsonArray(gitPlugin, updateCenterJson);
 
-        assertEquals(gitJson, null);
+        assertThat(gitJson).isNull();
 
         JSONArray awsCodeBuildJson = pm.getPluginDependencyJsonArray(awsCodeBuildPlugin, updateCenterJson);
-        assertEquals(awsCodebuildDependencies.toString(), awsCodeBuildJson.toString());
+        assertThat(awsCodeBuildJson).hasToString(awsCodebuildDependencies.toString());
 
         JSONArray awsGlobalConfJson = pm.getPluginDependencyJsonArray(awsGlobalConfigPlugin, updateCenterJson);
-        assertEquals(awsGlobalConfigDependencies.toString(), awsGlobalConfJson.toString());
+        assertThat(awsGlobalConfJson).hasToString(awsGlobalConfigDependencies.toString());
     }
 
     @Test
@@ -441,21 +440,24 @@ public class PluginManagerTest {
         Plugin gitPlugin = new Plugin("git", "1.17", null, null);
         JSONArray gitJson = pm.getPluginDependencyJsonArray(gitPlugin, pluginVersionJson);
 
-        assertEquals(gitJson, null);
+        assertThat(gitJson).isNull();
 
         pm.setPluginInfoJson(pluginVersionJson);
 
         Plugin browserStackPlugin1 = new Plugin("browserstack-integration", "1.0.0", null, null);
         JSONArray browserStackPluginJson1 = pm.getPluginDependencyJsonArray(browserStackPlugin1, pluginVersionJson);
-        assertEquals(dependencies1.toString(), browserStackPluginJson1.toString());
+        assertThat(browserStackPluginJson1)
+                .hasToString(dependencies1.toString());
 
         Plugin browserStackPlugin111 = new Plugin("browserstack-integration", "1.1.1", null, null);
         JSONArray browserStackPluginJson111 = pm.getPluginDependencyJsonArray(browserStackPlugin111, pluginVersionJson);
-        assertEquals(dependencies111.toString(), browserStackPluginJson111.toString());
+        assertThat(browserStackPluginJson111)
+                .hasToString(dependencies111.toString());
 
         Plugin browserStackPlugin112 = new Plugin("browserstack-integration", "1.1.2", null, null);
         JSONArray browserStackPluginJson112 = pm.getPluginDependencyJsonArray(browserStackPlugin112, pluginVersionJson);
-        assertEquals(dependencies112.toString(), browserStackPluginJson112.toString());
+        assertThat(browserStackPluginJson112)
+                .hasToString(dependencies112.toString());
     }
 
     @Test
@@ -464,44 +466,38 @@ public class PluginManagerTest {
 
         Map<String, List<SecurityWarning>> allSecurityWarnings = pm.getSecurityWarnings();
 
-        assertEquals(null, allSecurityWarnings.get("core"));
-
-        assertEquals(3, allSecurityWarnings.size());
+        assertThat(allSecurityWarnings)
+                .doesNotContainKey("core")
+                .hasSize(3);
 
         SecurityWarning googleLoginSecurityWarning = allSecurityWarnings.get("google-login").get(0);
-        assertEquals("SECURITY-208", googleLoginSecurityWarning.getId());
-        assertEquals("1[.][01](|[.-].*)", googleLoginSecurityWarning.getSecurityVersions().get(0).getPattern().toString());
+        assertThat(googleLoginSecurityWarning.getId()).isEqualTo("SECURITY-208");
+        assertThat(googleLoginSecurityWarning.getSecurityVersions().get(0).getPattern())
+                .hasToString("1[.][01](|[.-].*)");
 
         List<SecurityWarning> pipelineMavenSecurityWarning = allSecurityWarnings.get("pipeline-maven");
 
-        assertEquals(2, pipelineMavenSecurityWarning.size());
+        assertThat(pipelineMavenSecurityWarning)
+                .extracting(warning -> warning.getId() + " " + warning.getMessage() + " " + warning.getUrl())
+                .containsExactlyInAnyOrder(
+                        "SECURITY-441 Arbitrary files from Jenkins master available in Pipeline by using the " +
+                                "withMaven step https://jenkins.io/security/advisory/2017-03-09/",
+                        "SECURITY-1409 XML External Entity processing vulnerability " +
+                                "https://jenkins.io/security/advisory/2019-05-31/#SECURITY-1409");
 
-        List<String> securityWarningInfo = new ArrayList<>();
-        for (SecurityWarning securityWarning : pipelineMavenSecurityWarning) {
-            securityWarningInfo.add(securityWarning.getId() + " " + securityWarning.getMessage() + " " + securityWarning.getUrl());
-        }
-        Collections.sort(securityWarningInfo);
-        List<String> expectedSecurityInfo = new ArrayList<>();
-        expectedSecurityInfo.add("SECURITY-441 Arbitrary files from Jenkins master available in Pipeline by using the " +
-                        "withMaven step https://jenkins.io/security/advisory/2017-03-09/");
-        expectedSecurityInfo.add("SECURITY-1409 XML External Entity processing vulnerability " +
-                "https://jenkins.io/security/advisory/2019-05-31/#SECURITY-1409");
-        Collections.sort(expectedSecurityInfo);
-
-        assertEquals(expectedSecurityInfo, securityWarningInfo);
-
-        assertEquals(2, pipelineMavenSecurityWarning.get(0).getSecurityVersions().size());
+        assertThat(pipelineMavenSecurityWarning.get(0).getSecurityVersions())
+                .hasSize(2);
     }
 
     @Test
     public void getSecurityWarningsWhenNoWarningsTest() {
         JSONObject json = setTestUcJson();
         json.remove("warnings");
-        assertFalse(json.has("warnings"));
+        assertThat(json.has("warnings")).isFalse();
 
         Map<String, List<SecurityWarning>> allSecurityWarnings = pm.getSecurityWarnings();
 
-        assertEquals(0, allSecurityWarnings.size());
+        assertThat(allSecurityWarnings).isEmpty();
     }
 
     @Test
@@ -544,15 +540,15 @@ public class PluginManagerTest {
         Plugin sshAgents1 = new Plugin("ssh-slaves", "0.9", null, null);
         Plugin sshAgents2 = new Plugin("ssh-slaves", "9.2", null, null);
 
-        assertEquals(true, pm.warningExists(scriptler));
-        assertEquals(true, pm.warningExists(lockableResource));
-        assertEquals(false, pm.warningExists(lockableResource2));
-        assertEquals(false, pm.warningExists(cucumberReports1));
-        assertEquals(true, pm.warningExists(cucumberReports2));
-        //assertEquals(false, pm.warningExists(cucumberReports3));
+        assertThat(pm.warningExists(scriptler)).isTrue();
+        assertThat(pm.warningExists(lockableResource)).isTrue();
+        assertThat(pm.warningExists(lockableResource2)).isFalse();
+        assertThat(pm.warningExists(cucumberReports1)).isFalse();
+        assertThat(pm.warningExists(cucumberReports2)).isTrue();
+        //assertThat(pm.warningExists(cucumberReports3)).isFalse();
         // currently fails since 2.5.3 matches pattern even though 2.5.1 is last effected version
-        assertEquals(true, pm.warningExists(sshAgents1));
-        assertEquals(false, pm.warningExists(sshAgents2));
+        assertThat(pm.warningExists(sshAgents1)).isTrue();
+        assertThat(pm.warningExists(sshAgents2)).isFalse();
     }
 
     @Test
@@ -581,9 +577,8 @@ public class PluginManagerTest {
 
         List<Plugin> pluginsToDownload = new ArrayList<>(Arrays.asList(plugin1, plugin2));
 
-        assertThrows(
-                VersionCompatibilityException.class,
-                () -> pm.checkVersionCompatibility(pluginsToDownload));
+        assertThatThrownBy(() -> pm.checkVersionCompatibility(pluginsToDownload))
+                .isInstanceOf(VersionCompatibilityException.class);
     }
 
     @Test
@@ -618,7 +613,7 @@ public class PluginManagerTest {
         String output = tapSystemOutNormalized(
                 () -> pluginManager.showAvailableUpdates(plugins));
 
-        assertEquals("", output);
+        assertThat(output).isEmpty();
     }
 
     @Test
@@ -644,11 +639,10 @@ public class PluginManagerTest {
         String output = tapSystemOutNormalized(
                 () -> pluginManagerSpy.showAvailableUpdates(plugins));
 
-        String expectedOutput = "\nAvailable updates:\n" +
-                "ant (1.8) has an available update: 1.9\n" +
-                "amazon-ecs (1.15) has an available update: 1.20\n";
-
-        assertEquals(expectedOutput, output);
+        assertThat(output).isEqualTo(
+                "\nAvailable updates:\n"
+                        + "ant (1.8) has an available update: 1.9\n"
+                        + "amazon-ecs (1.15) has an available update: 1.20\n");
     }
 
     @Test
@@ -668,7 +662,7 @@ public class PluginManagerTest {
 
         pluginManagerSpy.downloadPlugins(plugins);
 
-        assertEquals(true, pluginManagerSpy.getFailedPlugins().isEmpty());
+        assertThat(pluginManagerSpy.getFailedPlugins()).isEmpty();
     }
 
     @Test
@@ -686,9 +680,8 @@ public class PluginManagerTest {
         List<Plugin> plugins = singletonList(
                 new Plugin("plugin", "1.0", null, null));
 
-        assertThrows(
-                DownloadPluginException.class,
-                () -> pluginManagerSpy.downloadPlugins(plugins));
+        assertThatThrownBy(() -> pluginManagerSpy.downloadPlugins(plugins))
+                .isInstanceOf(DownloadPluginException.class);
     }
 
     @Test
@@ -699,7 +692,8 @@ public class PluginManagerTest {
 
         pm.setInstalledPluginVersions(installedVersions);
 
-        assertEquals(true, pm.downloadPlugin(new Plugin("plugin1", "1.0", null, null), null));
+        assertThat(pm.downloadPlugin(new Plugin("plugin1", "1.0", null, null), null))
+                .isTrue();
     }
 
     @Test
@@ -723,9 +717,9 @@ public class PluginManagerTest {
         doReturn("url").when(pluginManagerSpy).getPluginDownloadUrl(pluginToDownload);
         doReturn(true).when(pluginManagerSpy).downloadToFile("url", pluginToDownload, null);
 
-        assertEquals(true, pluginManagerSpy.downloadPlugin(pluginToDownload, null));
-        assertEquals("plugin", pluginToDownload.getName());
-        assertEquals("plugin", pluginToDownload.getOriginalName());
+        assertThat(pluginManagerSpy.downloadPlugin(pluginToDownload, null)).isTrue();
+        assertThat(pluginToDownload.getName()).isEqualTo("plugin");
+        assertThat(pluginToDownload.getOriginalName()).isEqualTo("plugin");
     }
 
     @Test
@@ -752,7 +746,7 @@ public class PluginManagerTest {
         pm.checkAndSetLatestUpdateCenter();
 
         String expected = dirName(cfg.getJenkinsUc()) + pm.getJenkinsVersion() + Settings.DEFAULT_UPDATE_CENTER_FILENAME;
-        assertEquals(expected, pm.getJenkinsUCLatest());
+        assertThat(pm.getJenkinsUCLatest()).isEqualTo(expected);
     }
 
     @Test
@@ -771,20 +765,18 @@ public class PluginManagerTest {
         lowerVersion.setParent(lowerVersionParent);
         higherVersion.setParent(highVersionParent);
 
-        String expected = "Version of plugin1 (1.0) required by plugin1parent1 (1.0.0) is lower than the version " +
-                "required (2.0) by plugin1parent2 (2.0.0), upgrading required plugin version\n";
-
         String output = tapSystemOutNormalized(
                 () -> pluginManager.outputPluginReplacementInfo(lowerVersion, higherVersion));
 
-        assertEquals(expected, output);
+        assertThat(output).isEqualTo(
+                "Version of plugin1 (1.0) required by plugin1parent1 (1.0.0) is lower than the version " +
+                        "required (2.0) by plugin1parent2 (2.0.0), upgrading required plugin version\n");
     }
 
     @Test
     public void getJsonURLExceptionTest() {
-        assertThrows(
-                UpdateCenterInfoRetrievalException.class,
-                () -> pm.getJson("htttp://ftp-chi.osuosl.org/pub/jenkins/updates/current/update-center.json"));
+        assertThatThrownBy(() -> pm.getJson("htttp://ftp-chi.osuosl.org/pub/jenkins/updates/current/update-center.json"))
+                .isInstanceOf(UpdateCenterInfoRetrievalException.class);
     }
 
     @Test
@@ -795,9 +787,8 @@ public class PluginManagerTest {
 
         pm.setCm(new CacheManager(folder.newFolder().toPath(), false));
 
-        assertThrows(
-                UpdateCenterInfoRetrievalException.class,
-                () -> pm.getJson(new URL("http://ftp-chi.osuosl.org/pub/jenkins/updates/current/update-center.json"), "update-center"));
+        assertThatThrownBy(() -> pm.getJson(new URL("http://ftp-chi.osuosl.org/pub/jenkins/updates/current/update-center.json"), "update-center"))
+                .isInstanceOf(UpdateCenterInfoRetrievalException.class);
     }
 
     @Test
@@ -822,7 +813,7 @@ public class PluginManagerTest {
 
         pm.checkAndSetLatestUpdateCenter();
         String expected = cfg.getJenkinsUc().toString();
-        assertEquals(expected, pm.getJenkinsUCLatest());
+        assertThat(pm.getJenkinsUCLatest()).isEqualTo(expected);
     }
 
     @Test
@@ -841,9 +832,8 @@ public class PluginManagerTest {
 
         actualPlugins = pm.findPluginsToDownload(requestedPlugins);
 
-        assertEquals(
-                singletonList(new Plugin("git", "1.0.0", null, null)),
-                actualPlugins);
+        assertThat(actualPlugins)
+                .containsExactly(new Plugin("git", "1.0.0", null, null));
 
         requestedPlugins.put("credentials", new Plugin("credentials", "2.1.14", null, null));
         requestedPlugins.put("structs", new Plugin("structs", "1.18", null, null));
@@ -859,12 +849,11 @@ public class PluginManagerTest {
 
         actualPlugins = pm.findPluginsToDownload(requestedPlugins);
 
-        List<Plugin> expected = Arrays.asList(
-                new Plugin("credentials", "2.1.14", null, null),
-                new Plugin("structs", "1.18", null, null),
-                new Plugin("ssh-credentials", "1.13", null, null));
-
-        assertEquals(expected, actualPlugins);
+        assertThat(actualPlugins)
+                .containsExactlyInAnyOrder(
+                        new Plugin("credentials", "2.1.14", null, null),
+                        new Plugin("structs", "1.18", null, null),
+                        new Plugin("ssh-credentials", "1.13", null, null));
     }
 
     @Test
@@ -872,31 +861,30 @@ public class PluginManagerTest {
         URL jpiURL = this.getClass().getResource("/delivery-pipeline-plugin.jpi");
         File testJpi = new File(jpiURL.getFile());
 
-        assertEquals("1.3.2", pm.getPluginVersion(testJpi));
+        assertThat(pm.getPluginVersion(testJpi)).isEqualTo("1.3.2");
 
         URL hpiURL = this.getClass().getResource("/ssh-credentials.hpi");
         File testHpi = new File(hpiURL.getFile());
 
-        assertEquals("1.10", pm.getPluginVersion(testHpi));
+        assertThat(pm.getPluginVersion(testHpi)).isEqualTo("1.10");
     }
 
     @Test
     public void getLatestPluginVersionExceptionTest() {
         setTestUcJson();
 
-        assertThrows(
-                PluginNotFoundException.class,
-                () -> pm.getLatestPluginVersion("git"));
+        assertThatThrownBy(() -> pm.getLatestPluginVersion("git"))
+                .isInstanceOf(PluginNotFoundException.class);
     }
 
     @Test
     public void getLatestPluginTest() {
         setTestUcJson();
         VersionNumber antLatestVersion = pm.getLatestPluginVersion("ant");
-        assertEquals("1.9", antLatestVersion.toString());
+        assertThat(antLatestVersion).hasToString("1.9");
 
         VersionNumber amazonEcsLatestVersion = pm.getLatestPluginVersion("amazon-ecs");
-        assertEquals("1.20", amazonEcsLatestVersion.toString());
+        assertThat(amazonEcsLatestVersion).hasToString("1.20");
     }
 
     @Test
@@ -926,14 +914,13 @@ public class PluginManagerTest {
         doReturn(new VersionNumber("2.4")).doReturn(new VersionNumber("2.20")).when(pluginManagerSpy).
                 getLatestPluginVersion(any(String.class));
 
-        List<Plugin> expectedPlugins = Arrays.asList(
-                new Plugin("workflow-scm-step", "2.4", null, null),
-                new Plugin("workflow-step-api", "2.20", null, null));
-
         List<Plugin> actualPlugins = pluginManagerSpy.resolveDependenciesFromManifest(testPlugin);
 
-        assertEquals(expectedPlugins, actualPlugins);
-        assertEquals(testPlugin.getVersion().toString(), "1.0.0");
+        assertThat(actualPlugins)
+                .containsExactlyInAnyOrder(
+                        new Plugin("workflow-scm-step", "2.4", null, null),
+                        new Plugin("workflow-step-api", "2.20", null, null));
+        assertThat(testPlugin.getVersion()).hasToString("1.0.0");
     }
 
     @Test
@@ -963,13 +950,12 @@ public class PluginManagerTest {
         doReturn(new VersionNumber("2.4")).doReturn(new VersionNumber("2.20")).when(pluginManagerSpy).
                 getLatestPluginVersion(any(String.class));
 
-        List<Plugin> expectedPlugins = Arrays.asList(
-                new Plugin("workflow-scm-step", "2.4", null, null),
-                new Plugin("workflow-step-api", "2.20", null, null));
-
         List<Plugin> actualPlugins = pluginManagerSpy.resolveDependenciesFromManifest(testPlugin);
 
-        assertEquals(expectedPlugins, actualPlugins);
+        assertThat(actualPlugins)
+                .containsExactlyInAnyOrder(
+                        new Plugin("workflow-scm-step", "2.4", null, null),
+                        new Plugin("workflow-step-api", "2.20", null, null));
     }
 
     @Test
@@ -977,7 +963,7 @@ public class PluginManagerTest {
         mockStatic(Files.class);
         when(Files.createTempFile(any(String.class), any(String.class))).thenThrow(IOException.class);
         Plugin testPlugin = new Plugin("test", "latest", null, null);
-        assertEquals(true, pm.resolveDependenciesFromManifest(testPlugin).isEmpty());
+        assertThat(pm.resolveDependenciesFromManifest(testPlugin)).isEmpty();
     }
 
     @Test
@@ -1000,9 +986,8 @@ public class PluginManagerTest {
         when(Files.createTempFile(any(String.class), any(String.class))).thenReturn(tempPath);
         when(tempPath.toFile()).thenReturn(tempFile);
 
-        assertThrows(
-                DownloadPluginException.class,
-                () -> pluginManager.resolveDependenciesFromManifest(testPlugin));
+        assertThatThrownBy(() -> pluginManager.resolveDependenciesFromManifest(testPlugin))
+                .isInstanceOf(DownloadPluginException.class);
     }
 
     @Test
@@ -1027,19 +1012,18 @@ public class PluginManagerTest {
                 "token-macro:1.12.1;resolution:=optional")
                 .when(pluginManagerSpy).getAttributeFromManifest(any(File.class), any(String.class));
 
-        List<Plugin> expectedPlugins = Arrays.asList(
-                new Plugin("workflow-scm-step", "2.4", null, null),
-                new Plugin("workflow-step-api", "2.13", null, null),
-                new Plugin("credentials", "2.1.14", null, null),
-                new Plugin("git-client", "2.7.7", null, null),
-                new Plugin("mailer", "1.18", null, null),
-                new Plugin("scm-api", "2.6.3", null, null),
-                new Plugin("ssh-credentials", "1.13", null, null));
-
         List<Plugin> actualPlugins = pluginManagerSpy.resolveDependenciesFromManifest(testPlugin);
 
-        assertEquals(expectedPlugins, actualPlugins);
-        assertEquals(testPlugin.getVersion().toString(), "1.0.0");
+        assertThat(actualPlugins)
+                .containsExactlyInAnyOrder(
+                        new Plugin("workflow-scm-step", "2.4", null, null),
+                        new Plugin("workflow-step-api", "2.13", null, null),
+                        new Plugin("credentials", "2.1.14", null, null),
+                        new Plugin("git-client", "2.7.7", null, null),
+                        new Plugin("mailer", "1.18", null, null),
+                        new Plugin("scm-api", "2.6.3", null, null),
+                        new Plugin("ssh-credentials", "1.13", null, null));
+        assertThat(testPlugin.getVersion()).hasToString("1.0.0");
     }
 
     @Test
@@ -1051,7 +1035,7 @@ public class PluginManagerTest {
 
         List<Plugin> actualPlugins = pluginManagerSpy.resolveDirectDependencies(plugin);
 
-        assertEquals(directDependencyExpectedPlugins, actualPlugins);
+        assertThat(actualPlugins).isEqualTo(directDependencyExpectedPlugins);
     }
 
 
@@ -1065,7 +1049,7 @@ public class PluginManagerTest {
 
         List<Plugin> actualPlugins = pluginManagerSpy.resolveDirectDependencies(plugin);
 
-        assertEquals(directDependencyExpectedPlugins, actualPlugins);
+        assertThat(actualPlugins).isEqualTo(directDependencyExpectedPlugins);
     }
 
     @Test
@@ -1081,7 +1065,7 @@ public class PluginManagerTest {
 
         List<Plugin> actualPlugins = pluginManagerSpy.resolveDirectDependencies(plugin);
 
-        assertEquals(directDependencyExpectedPlugins, actualPlugins);
+        assertThat(actualPlugins).isEqualTo(directDependencyExpectedPlugins);
     }
 
 
@@ -1095,7 +1079,7 @@ public class PluginManagerTest {
 
         List<Plugin> actualPlugins = pluginManagerSpy.resolveDirectDependencies(plugin);
 
-        assertEquals(directDependencyExpectedPlugins, actualPlugins);
+        assertThat(actualPlugins).isEqualTo(directDependencyExpectedPlugins);
     }
 
     @Test
@@ -1108,7 +1092,7 @@ public class PluginManagerTest {
 
         List<Plugin> actualPlugins = pluginManagerSpy.resolveDirectDependencies(plugin);
 
-        assertEquals(directDependencyExpectedPlugins, actualPlugins);
+        assertThat(actualPlugins).isEqualTo(directDependencyExpectedPlugins);
     }
 
     @Test
@@ -1118,7 +1102,7 @@ public class PluginManagerTest {
         Plugin mavenInvoker = new Plugin("maven-invoker-plugin", "2.4", null, null);
         List<Plugin> actualPlugins = pm.resolveDependenciesFromJson(mavenInvoker, json);
 
-        assertEquals(directDependencyExpectedPlugins, actualPlugins);
+        assertThat(actualPlugins).isEqualTo(directDependencyExpectedPlugins);
     }
 
     @Test
@@ -1139,9 +1123,8 @@ public class PluginManagerTest {
         testWeaver.setLatest(true);
         List<Plugin> actualPlugins = pluginManager.resolveDependenciesFromJson(testWeaver, testJson);
 
-        assertEquals(
-                singletonList(new Plugin("structs", "1.19", null, null)),
-                actualPlugins);
+        assertThat(actualPlugins)
+                .containsExactly(new Plugin("structs", "1.19", null, null));
     }
 
     @Test
@@ -1196,15 +1179,14 @@ public class PluginManagerTest {
                 .doReturn(new VersionNumber("2.0"))
                 .when(pluginManagerSpy).getLatestPluginVersion(any(String.class));
 
-        List<Plugin> expectedPlugins = Arrays.asList(
-                new Plugin("workflow-api", "2.44", null, null),
-                new Plugin("workflow-step-api", "2.30", null, null),
-                new Plugin("mailer", "1.18", null, null),
-                new Plugin("script-security", "2.0", null, null));
-
         List<Plugin> actualPlugins = pluginManagerSpy.resolveDependenciesFromJson(mvnInvokerPlugin, pluginJson);
 
-        assertEquals(expectedPlugins, actualPlugins);
+        assertThat(actualPlugins)
+                .containsExactlyInAnyOrder(
+                        new Plugin("workflow-api", "2.44", null, null),
+                        new Plugin("workflow-step-api", "2.30", null, null),
+                        new Plugin("mailer", "1.18", null, null),
+                        new Plugin("script-security", "2.0", null, null));
     }
 
     @Test
@@ -1240,26 +1222,16 @@ public class PluginManagerTest {
         child1.setDependencies(singletonList(child6));
         child8.setDependencies(singletonList(child5));
 
-        Set<Plugin> expectedDependencies = new HashSet<>();
-        expectedDependencies.add(grandParent);
-        expectedDependencies.add(parent1);
-        expectedDependencies.add(child4);  //highest version of replaced1
-        expectedDependencies.add(parent3);
-        expectedDependencies.add(child2);
-        expectedDependencies.add(child3);
-        expectedDependencies.add(child8);
-        expectedDependencies.add(child9);
-        expectedDependencies.add(child5);
-        expectedDependencies.add(child6);
-
         //See Jira JENKINS-58775 - the ideal solution has the following dependencies: grandparent, parent1, child4,
         //parent3, child2, child8, child3, and child9
 
         Map<String, Plugin> recursiveDependencies = pluginManagerSpy.resolveRecursiveDependencies(grandParent);
 
-        Set<Plugin> actualDependencies = new HashSet<>(recursiveDependencies.values());
-
-        assertEquals(expectedDependencies, actualDependencies);
+        assertThat(recursiveDependencies)
+                .hasSize(10)
+                .containsValues(
+                        grandParent, parent1, child4, parent3, child2, child3,
+                        child8, child9, child5, child6);
     }
 
 
@@ -1283,13 +1255,13 @@ public class PluginManagerTest {
         String tmp1name = FilenameUtils.getBaseName(tmp1.getName());
         String tmp2name = FilenameUtils.getBaseName(tmp2.getName());
 
-        Set<Plugin> expectedPlugins = new HashSet<>(Arrays.asList(
-                new Plugin(tmp1name, "1.3.2", null, null),
-                new Plugin(tmp2name, "1.8", null, null)));
-
         Map<String, Plugin> actualPlugins = pm.installedPlugins();
 
-        assertEquals(expectedPlugins, new HashSet<>(actualPlugins.values()));
+        assertThat(actualPlugins)
+                .hasSize(2)
+                .containsValues(
+                        new Plugin(tmp1name, "1.3.2", null, null),
+                        new Plugin(tmp2name, "1.8", null, null));
     }
 
     @Test
@@ -1339,14 +1311,14 @@ public class PluginManagerTest {
         JarFile pluginJpi = mock(JarFile.class);
 
         whenNew(JarFile.class).withAnyArguments().thenReturn(pluginJpi);
-        assertTrue(pm.downloadToFile("downloadURL", plugin, null));
+        assertThat(pm.downloadToFile("downloadURL", plugin, null)).isTrue();
     }
 
     @Test
     public void getPluginDownloadUrlTest() {
         Plugin plugin = new Plugin("pluginName", "pluginVersion", "pluginURL", null);
 
-        assertEquals("pluginURL", pm.getPluginDownloadUrl(plugin));
+        assertThat(pm.getPluginDownloadUrl(plugin)).isEqualTo("pluginURL");
 
         // Note: As of now (2019/12/18 lmm) there is no 'latest' folder in the cloudbees update center as a sibling of the "download" folder
         //  so this is only applicable on jenkins.io
@@ -1358,7 +1330,7 @@ public class PluginManagerTest {
         Assert.assertEquals(latestUrl, pm.getPluginDownloadUrl(pluginNoUrl));
 
         Plugin pluginNoVersion = new Plugin("pluginName", null, null, null);
-        assertEquals(latestUrl, pm.getPluginDownloadUrl(pluginNoVersion));
+        assertThat(pm.getPluginDownloadUrl(pluginNoVersion)).isEqualTo(latestUrl);
 
         Plugin pluginExperimentalVersion = new Plugin("pluginName", "experimental", null, null);
         String experimentalUrl = dirName(cfg.getJenkinsUcExperimental()) + "latest/pluginName.hpi";
@@ -1369,12 +1341,12 @@ public class PluginManagerTest {
         String incrementalUrl = cfg.getJenkinsIncrementalsRepoMirror() +
                 "/org/jenkins-ci/plugins/pluginName/pluginName/2.19-rc289.d09828a05a74/pluginName-2.19-rc289.d09828a05a74.hpi";
 
-        assertEquals(incrementalUrl, pm.getPluginDownloadUrl(pluginIncrementalRepo));
+        assertThat(pm.getPluginDownloadUrl(pluginIncrementalRepo)).isEqualTo(incrementalUrl);
 
         Plugin pluginOtherVersion = new Plugin("pluginName", "otherversion", null, null);
         String otherURL = dirName(cfg.getJenkinsUc().toString()) +
                 "download/plugins/pluginName/otherversion/pluginName.hpi";
-        assertEquals(otherURL, pm.getPluginDownloadUrl(pluginOtherVersion));
+        assertThat(pm.getPluginDownloadUrl(pluginOtherVersion)).isEqualTo(otherURL);
     }
 
     @Test
@@ -1391,7 +1363,7 @@ public class PluginManagerTest {
 
         String result = pluginManager.getPluginDownloadUrl(plugin);
 
-        assertThat(result, is("https://jenkins-updates.cloudbees.com/download/plugins/the-plugin/1.0/the-plugin.hpi"));
+        assertThat(result).isEqualTo("https://jenkins-updates.cloudbees.com/download/plugins/the-plugin/1.0/the-plugin.hpi");
     }
 
     @Test
@@ -1401,9 +1373,8 @@ public class PluginManagerTest {
 
         whenNew(JarFile.class).withArguments(testJpi).thenThrow(new IOException());
 
-        assertThrows(
-                DownloadPluginException.class,
-                () -> pm.getAttributeFromManifest(testJpi, "Plugin-Dependencies"));
+        assertThatThrownBy(() -> pm.getAttributeFromManifest(testJpi, "Plugin-Dependencies"))
+                .isInstanceOf(DownloadPluginException.class);
     }
 
     public void getAttributeFromManifestTest() throws Exception {
@@ -1422,7 +1393,7 @@ public class PluginManagerTest {
         when(manifest.getMainAttributes()).thenReturn(attributes);
         when(attributes.getValue(key)).thenReturn(value);
 
-        assertEquals(value, pm.getAttributeFromManifest(testJpi, "key"));
+        assertThat(pm.getAttributeFromManifest(testJpi, "key")).isEqualTo(value);
     }
 
     public void showAllSecurityWarningsNoOutput() throws Exception {
@@ -1437,7 +1408,7 @@ public class PluginManagerTest {
         String output = tapSystemOutNormalized(
                 pluginManager::showAllSecurityWarnings);
 
-        assertEquals("", output);
+        assertThat(output).isEmpty();
     }
 
 
@@ -1455,12 +1426,11 @@ public class PluginManagerTest {
         String output = tapSystemOutNormalized(
                 pluginManager::showAllSecurityWarnings);
 
-        String expectedOutput = "google-login - Authentication bypass vulnerability\n" +
-                "cucumber-reports - Plugin disables Content-Security-Policy for files served by Jenkins\n" +
-                "pipeline-maven - Arbitrary files from Jenkins master available in Pipeline by using the withMaven step\n" +
-                "pipeline-maven - XML External Entity processing vulnerability\n";
-
-        assertEquals(expectedOutput, output);
+        assertThat(output).isEqualTo(
+                "google-login - Authentication bypass vulnerability\n" +
+                        "cucumber-reports - Plugin disables Content-Security-Policy for files served by Jenkins\n" +
+                        "pipeline-maven - Arbitrary files from Jenkins master available in Pipeline by using the withMaven step\n" +
+                        "pipeline-maven - XML External Entity processing vulnerability\n");
     }
 
 
@@ -1474,7 +1444,8 @@ public class PluginManagerTest {
                 .withJenkinsWar(testWar.toString())
                 .build();
         PluginManager pluginManager = new PluginManager(config);
-        assertEquals(new VersionNumber("2.164.1").compareTo(pluginManager.getJenkinsVersionFromWar()), 0);
+        assertThat(pluginManager.getJenkinsVersionFromWar())
+                .isEqualByComparingTo(new VersionNumber("2.164.1"));
     }
 
     @Test
@@ -1488,14 +1459,13 @@ public class PluginManagerTest {
                 .build();
         PluginManager pluginManager = new PluginManager(config);
 
-        Set<Plugin> expectedPlugins = new HashSet<>(Arrays.asList(
-                new Plugin("credentials","2.1.18", null, null),
-                new Plugin("display-url-api","2.0", null, null),
-                new Plugin("github-branch-source", "1.8", null, null)));
-
         Map<String, Plugin> actualPlugins = pluginManager.bundledPlugins();
 
-        assertEquals(expectedPlugins, new HashSet<>(actualPlugins.values()));
+        assertThat(actualPlugins.values())
+                .containsExactlyInAnyOrder(
+                        new Plugin("credentials","2.1.18", null, null),
+                        new Plugin("display-url-api","2.0", null, null),
+                        new Plugin("github-branch-source", "1.8", null, null));
     }
 
     private JSONObject setTestUcJson() {

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/util/PluginListParserTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/util/PluginListParserTest.java
@@ -5,24 +5,22 @@ import io.jenkins.tools.pluginmanager.impl.Plugin;
 import java.io.File;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
-import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class PluginListParserTest {
     PluginListParser pluginList;
-    List<String> expectedPluginInfo;
+    String[] expectedPluginInfo;
 
     @Before
     public void setup() {
         pluginList = new PluginListParser();
 
-        expectedPluginInfo = asList(
+        expectedPluginInfo = new String[]{
             new Plugin("git", "latest", null, null).toString(),
             new Plugin("job-import-plugin", "2.1", null, null).toString(),
             new Plugin("docker", "latest", null, null).toString(),
@@ -41,9 +39,7 @@ public class PluginListParserTest {
                     "https://updates.jenkins.io/latest/google-api-client-plugin.hpi", null).toString(),
             new Plugin("build-timeout", "1.20",
                     null, null).toString()
-        );
-
-        Collections.sort(expectedPluginInfo);
+        };
 
     }
 
@@ -69,20 +65,18 @@ public class PluginListParserTest {
             pluginInfo.add(p.toString());
         }
 
-        Collections.sort(pluginInfo);
-
-        assertEquals(expectedPluginInfo, pluginInfo);
+        assertThat(pluginInfo).containsExactlyInAnyOrder(expectedPluginInfo);
 
         List<Plugin> noPluginArrayList = pluginList.parsePluginsFromCliOption(null);
 
-        assertEquals(noPluginArrayList.size(), 0);
+        assertThat(noPluginArrayList).isEmpty();
 
     }
 
     @Test
     public void parsePluginTxtFileTest() throws URISyntaxException {
         List<Plugin> noFilePluginList = pluginList.parsePluginTxtFile(null);
-        assertEquals(noFilePluginList.size(), 0);
+        assertThat(noFilePluginList).isEmpty();
 
         File pluginTxtFile = new File(this.getClass().getResource("PluginListParserTest/plugins.txt").toURI());
 
@@ -93,15 +87,14 @@ public class PluginListParserTest {
             pluginInfo.add(p.toString());
         }
 
-        Collections.sort(pluginInfo);
-        assertEquals(expectedPluginInfo, pluginInfo);
+        assertThat(pluginInfo).containsExactlyInAnyOrder(expectedPluginInfo);
     }
 
 
     @Test
     public void parsePluginYamlFileTest() throws URISyntaxException {
         List<Plugin> noFilePluginList = pluginList.parsePluginYamlFile(null);
-        assertEquals(noFilePluginList.size(), 0);
+        assertThat(noFilePluginList).isEmpty();
 
         File pluginYmlFile = new File(this.getClass().getResource("PluginListParserTest/plugins.yaml").toURI());
 
@@ -113,42 +106,38 @@ public class PluginListParserTest {
             pluginInfo.add(p.toString());
         }
 
-        Collections.sort(pluginInfo);
-        assertEquals(expectedPluginInfo, pluginInfo);
+        assertThat(pluginInfo).containsExactlyInAnyOrder(expectedPluginInfo);
     }
 
     @Test
     public void badFormatYamlNoArtifactIdTest() throws URISyntaxException {
         File pluginYmlFile = new File(this.getClass().getResource("PluginListParserTest/badformat1.yaml").toURI());
-        assertThrows(
-                PluginInputException.class,
-                () -> pluginList.parsePluginYamlFile(pluginYmlFile));
+        assertThatThrownBy(() -> pluginList.parsePluginYamlFile(pluginYmlFile))
+                .isInstanceOf(PluginInputException.class);
     }
 
     @Test
     public void badFormatYamlGroupIdNoVersion() throws URISyntaxException {
         File pluginYmlFile = new File(this.getClass().getResource("PluginListParserTest/badformat2.yaml").toURI());
-        assertThrows(
-                PluginInputException.class,
-                () -> pluginList.parsePluginYamlFile(pluginYmlFile));
+        assertThatThrownBy(() -> pluginList.parsePluginYamlFile(pluginYmlFile))
+                .isInstanceOf(PluginInputException.class);
     }
 
     @Test
     public void badFormatYamlGroupIdNoVersion2() throws URISyntaxException {
         File pluginYmlFile = new File(this.getClass().getResource("PluginListParserTest/badformat3.yaml").toURI());
-        assertThrows(
-                PluginInputException.class,
-                () -> pluginList.parsePluginYamlFile(pluginYmlFile));
+        assertThatThrownBy(() -> pluginList.parsePluginYamlFile(pluginYmlFile))
+                .isInstanceOf(PluginInputException.class);
     }
 
     @Test
     public void fileExistsTest() throws URISyntaxException {
-        assertEquals(false, pluginList.fileExists(null));
+        assertThat(pluginList.fileExists(null)).isFalse();
 
         File pluginFile = new File(this.getClass().getResource("PluginListParserTest/plugins.yaml").toURI());
-        assertEquals(true, pluginList.fileExists(pluginFile));
+        assertThat(pluginList.fileExists(pluginFile)).isTrue();
 
         File notExistingFile = new File("/file/that/does/not/exist.yaml");
-        assertEquals(false, pluginList.fileExists(notExistingFile));
+        assertThat(pluginList.fileExists(notExistingFile)).isFalse();
     }
 }

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/util/PluginManagerUtilsTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/util/PluginManagerUtilsTest.java
@@ -5,8 +5,7 @@ import java.net.URL;
 import org.json.JSONObject;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PluginManagerUtilsTest {
 
@@ -14,119 +13,119 @@ public class PluginManagerUtilsTest {
     public void appendPathOntoUrlObjectsTest() throws MalformedURLException {
         String result = PluginManagerUtils.appendPathOntoUrl(new URL("http://bob.com:8080"), new StringBuilder("file.json"));
 
-        assertThat(result, is("http://bob.com:8080/file.json"));
+        assertThat(result).isEqualTo("http://bob.com:8080/file.json");
     }
 
     @Test
     public void appendPathOntoUrlObjectsMultiSegmentTest() throws MalformedURLException {
         String result = PluginManagerUtils.appendPathOntoUrl(new URL("http://bob.com:8080"), new StringBuilder("path/to"), new StringBuilder("file.json"));
 
-        assertThat(result, is("http://bob.com:8080/path/to/file.json"));
+        assertThat(result).isEqualTo("http://bob.com:8080/path/to/file.json");
     }
 
     @Test
     public void appendPathOntoUrlTest() {
         String result = PluginManagerUtils.appendPathOntoUrl("http://bob.com:8080", "file.json");
 
-        assertThat(result, is("http://bob.com:8080/file.json"));
+        assertThat(result).isEqualTo("http://bob.com:8080/file.json");
     }
 
     @Test
     public void appendPathOntoUrlTestBlankUrl() {
         String result = PluginManagerUtils.appendPathOntoUrl("", "file.json");
 
-        assertThat(result, is("file.json"));
+        assertThat(result).isEqualTo("file.json");
     }
 
     @Test
     public void appendPathOntoUrlTestNoUrl() {
         String result = PluginManagerUtils.appendPathOntoUrl(null, "file.json");
 
-        assertThat(result, is("file.json"));
+        assertThat(result).isEqualTo("file.json");
     }
 
     @Test
     public void appendPathOntoUrlWithUrlTrailingSlashTest() {
         String result = PluginManagerUtils.appendPathOntoUrl("http://bob.com:8080/", "file.json");
 
-        assertThat(result, is("http://bob.com:8080/file.json"));
+        assertThat(result).isEqualTo("http://bob.com:8080/file.json");
     }
 
     @Test
     public void appendPathOntoUrlWithPathLeadingSlashTest() {
         String result = PluginManagerUtils.appendPathOntoUrl("http://bob.com:8080", "/file.json");
 
-        assertThat(result, is("http://bob.com:8080/file.json"));
+        assertThat(result).isEqualTo("http://bob.com:8080/file.json");
     }
 
     @Test
     public void appendPathOntoUrlWithPathTrailingAndLeadingSlashTest() {
         String result = PluginManagerUtils.appendPathOntoUrl("http://bob.com:8080/", "/file.json");
 
-        assertThat(result, is("http://bob.com:8080/file.json"));
+        assertThat(result).isEqualTo("http://bob.com:8080/file.json");
     }
 
     @Test
     public void appendPathOntoUrlNoDomainNameTest() {
         String result = PluginManagerUtils.appendPathOntoUrl("anything://", "bob.com/file.json");
 
-        assertThat(result, is("anything://bob.com/file.json"));
+        assertThat(result).isEqualTo("anything://bob.com/file.json");
     }
 
     @Test
     public void appendPathOntoUrlWithBlankPathTest() {
         String result = PluginManagerUtils.appendPathOntoUrl("http://bob.com:8080", "");
 
-        assertThat(result, is("http://bob.com:8080"));
+        assertThat(result).isEqualTo("http://bob.com:8080");
     }
 
     @Test
     public void appendPathOntoUrlWithNoPathTest() {
         String result = PluginManagerUtils.appendPathOntoUrl("http://bob.com:8080", (String[]) null);
 
-        assertThat(result, is("http://bob.com:8080"));
+        assertThat(result).isEqualTo("http://bob.com:8080");
     }
 
     @Test
     public void appendPathOntoUrlWithNullPathTest() {
         String result = PluginManagerUtils.appendPathOntoUrl("http://bob.com:8080", (String) null);
 
-        assertThat(result, is("http://bob.com:8080"));
+        assertThat(result).isEqualTo("http://bob.com:8080");
     }
 
     @Test
     public void appendPathOntoUrlMultiSegmentTest() {
         String result = PluginManagerUtils.appendPathOntoUrl("http://bob.com:8080", "path/to", "file.json");
 
-        assertThat(result, is("http://bob.com:8080/path/to/file.json"));
+        assertThat(result).isEqualTo("http://bob.com:8080/path/to/file.json");
     }
 
     @Test
     public void appendPathOntoUrlMultiSegmentTrailingSlashTest() {
         String result = PluginManagerUtils.appendPathOntoUrl("http://bob.com:8080/", "path/to/", "file.json");
 
-        assertThat(result, is("http://bob.com:8080/path/to/file.json"));
+        assertThat(result).isEqualTo("http://bob.com:8080/path/to/file.json");
     }
 
     @Test
     public void appendPathOntoUrlMultiSegmentLeadingSlashTest() {
         String result = PluginManagerUtils.appendPathOntoUrl("http://bob.com:8080", "/path/to", "/file.json");
 
-        assertThat(result, is("http://bob.com:8080/path/to/file.json"));
+        assertThat(result).isEqualTo("http://bob.com:8080/path/to/file.json");
     }
 
     @Test
     public void appendPathOntoUrlMultiSegmentTrailingAndLeadingSlashTest() {
         String result = PluginManagerUtils.appendPathOntoUrl("http://bob.com:8080/", "/path/to/", "/file.json");
 
-        assertThat(result, is("http://bob.com:8080/path/to/file.json"));
+        assertThat(result).isEqualTo("http://bob.com:8080/path/to/file.json");
     }
 
     @Test
     public void appendPathOntoUrlMultiSegmentOneBlankTest() {
         String result = PluginManagerUtils.appendPathOntoUrl("http://bob.com:8080/", "", "/file.json");
 
-        assertThat(result, is("http://bob.com:8080/file.json"));
+        assertThat(result).isEqualTo("http://bob.com:8080/file.json");
     }
 
     @Test
@@ -135,7 +134,7 @@ public class PluginManagerUtilsTest {
         String noActual = "updateCenter.post(" + json + ");";
 
         String result = PluginManagerUtils.removePossibleWrapperText(noActual);
-        assertThat(json, is(result));
+        assertThat(result).isEqualTo(json);
 
         new JSONObject(result); // This asserts the result is valid json
     }
@@ -145,7 +144,7 @@ public class PluginManagerUtilsTest {
         String json = "{'json':'content', 'here':true}";
 
         String result = PluginManagerUtils.removePossibleWrapperText(json);
-        assertThat(json, is(result));
+        assertThat(result).isEqualTo(json);
 
         new JSONObject(result); // This asserts the result is valid json
     }
@@ -156,7 +155,7 @@ public class PluginManagerUtilsTest {
         String noActual = "updateCenter.post(" + json + ");\n";
 
         String result = PluginManagerUtils.removePossibleWrapperText(noActual);
-        assertThat(json, is(result));
+        assertThat(result).isEqualTo(json);
 
         new JSONObject(result); // This asserts the result is valid json
     }
@@ -171,7 +170,7 @@ public class PluginManagerUtilsTest {
         String noActual = "updateCenter.post(" + json + ");";
 
         String result = PluginManagerUtils.removePossibleWrapperText(noActual);
-        assertThat(json, is(result));
+        assertThat(result).isEqualTo(json);
         new JSONObject(result); // This asserts the result is valid json
     }
 
@@ -179,84 +178,84 @@ public class PluginManagerUtilsTest {
     public void dirnameObjectTest() throws MalformedURLException {
         String result = PluginManagerUtils.dirName(new URL("http://bob.com/path/to/file.json"));
 
-        assertThat(result, is("http://bob.com/path/to/"));
+        assertThat(result).isEqualTo("http://bob.com/path/to/");
     }
 
     @Test
     public void dirnameTest() {
         String result = PluginManagerUtils.dirName("http://bob.com/path/to/file.json");
 
-        assertThat(result, is("http://bob.com/path/to/"));
+        assertThat(result).isEqualTo("http://bob.com/path/to/");
     }
 
     @Test
     public void dirnameTestNoPath() {
         String result = PluginManagerUtils.dirName("http://bob.com");
 
-        assertThat(result, is("http://bob.com"));
+        assertThat(result).isEqualTo("http://bob.com");
     }
 
     @Test
     public void dirnameTestNoPathPlusPort() {
         String result = PluginManagerUtils.dirName("http://bob.com:8080");
 
-        assertThat(result, is("http://bob.com:8080"));
+        assertThat(result).isEqualTo("http://bob.com:8080");
     }
 
     @Test
     public void dirnameTestNoSlashes() {
         String result = PluginManagerUtils.dirName("bob.com");
 
-        assertThat(result, is("bob.com"));
+        assertThat(result).isEqualTo("bob.com");
     }
 
     @Test
     public void removePathTest() throws MalformedURLException {
         String result = PluginManagerUtils.removePath(new URL("http://bob.com/path/to/file.json"));
 
-        assertThat(result, is("http://bob.com"));
+        assertThat(result).isEqualTo("http://bob.com");
     }
 
     @Test
     public void removePathTestWithPort() {
         String result = PluginManagerUtils.removePath("http://bob.com:8080/path/to/file.json");
 
-        assertThat(result, is("http://bob.com:8080"));
+        assertThat(result).isEqualTo("http://bob.com:8080");
     }
 
     @Test
     public void removePathTestNoPath() {
         String result = PluginManagerUtils.removePath("http://bob.com");
 
-        assertThat(result, is("http://bob.com"));
+        assertThat(result).isEqualTo("http://bob.com");
     }
 
     @Test
     public void insertPathPreservingFilenameObjectTest() throws MalformedURLException {
         String result = PluginManagerUtils.insertPathPreservingFilename(new URL("http://bob.com/update-center.json"), new StringBuilder("2.190"));
 
-        assertThat(result, is("http://bob.com/2.190/update-center.json"));
+        assertThat(result).isEqualTo("http://bob.com/2.190/update-center.json");
     }
 
     @Test
     public void insertPathPreservingFilenameTest() {
         String result = PluginManagerUtils.insertPathPreservingFilename("http://bob.com/update-center.json", "2.190");
 
-        assertThat(result, is("http://bob.com/2.190/update-center.json"));
+        assertThat(result).isEqualTo("http://bob.com/2.190/update-center.json");
     }
 
     @Test
     public void insertPathPreservingFilenameLongTest() {
         String result = PluginManagerUtils.insertPathPreservingFilename("http://bob.com/updates/plugins/update-center.json", "2.190");
 
-        assertThat(result, is("http://bob.com/updates/plugins/2.190/update-center.json"));
+        assertThat(result).isEqualTo("http://bob.com/updates/plugins/2.190/update-center.json");
     }
 
     @Test
     public void insertPathPreservingFilenameNoSlashes() {
         String result = PluginManagerUtils.insertPathPreservingFilename("path", "2.190");
 
-        assertThat(result, is("2.190/path"));
+        assertThat(result).isEqualTo("2.190/path");
     }
 
 }

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/util/URIStringBuilderTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/util/URIStringBuilderTest.java
@@ -1,10 +1,9 @@
 package io.jenkins.tools.pluginmanager.util;
 
-import io.jenkins.tools.pluginmanager.util.URIStringBuilder;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class URIStringBuilderTest {
 
@@ -12,7 +11,7 @@ public class URIStringBuilderTest {
     public void constructorTest() {
         String result = new URIStringBuilder("http://bob.com")
                 .build();
-        assertThat(result, is("http://bob.com"));
+        assertThat(result).isEqualTo("http://bob.com");
     }
 
     @Test
@@ -20,21 +19,21 @@ public class URIStringBuilderTest {
         String result = new URIStringBuilder("http://")
                 .addPath("bob.com")
                 .build();
-        assertThat(result, is("http://bob.com"));
+        assertThat(result).isEqualTo("http://bob.com");
     }
 
     @Test
     public void constructorWithTrailingSlashTest() {
         String result = new URIStringBuilder("http://bob.com/")
                 .build();
-        assertThat(result, is("http://bob.com"));
+        assertThat(result).isEqualTo("http://bob.com");
     }
 
     @Test
     public void dontAddPathTest() {
         String result = new URIStringBuilder("http://bob.com")
                 .build();
-        assertThat(result, is("http://bob.com"));
+        assertThat(result).isEqualTo("http://bob.com");
     }
 
     @Test
@@ -43,7 +42,7 @@ public class URIStringBuilderTest {
                 .addPath("path/to")
                 .addPath("file.html")
                 .build();
-        assertThat(result, is("http://bob.com/path/to/file.html"));
+        assertThat(result).isEqualTo("http://bob.com/path/to/file.html");
     }
 
     @Test
@@ -53,7 +52,7 @@ public class URIStringBuilderTest {
                 .addPath("")
                 .addPath("file.html")
                 .build();
-        assertThat(result, is("http://bob.com/path/to/file.html"));
+        assertThat(result).isEqualTo("http://bob.com/path/to/file.html");
     }
 
     @Test
@@ -61,6 +60,6 @@ public class URIStringBuilderTest {
         String result = new URIStringBuilder("http://bob.com")
                 .addPath("file.html")
                 .build();
-        assertThat(result, is("http://bob.com/file.html"));
+        assertThat(result).isEqualTo("http://bob.com/file.html");
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,15 @@
         </pluginRepository>
     </pluginRepositories>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>3.16.1</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.powermock</groupId>


### PR DESCRIPTION
Improve the readability of tests. E.g.

    assertThat(actualPlugins)
        .containsExactlyInAnyOrder(
            new Plugin("workflow-scm-step", "2.4", null, null),
            new Plugin("workflow-step-api", "2.20", null, null));

is easier to read than

    List<Plugin> expectedPlugins = Arrays.asList(
        new Plugin("workflow-scm-step", "2.4", null, null),
        new Plugin("workflow-step-api", "2.20", null, null));
    assertEquals(expectedPlugins, actualPlugins);

and also more specific because it explicitly states that the order does
not matter.

Also the messages for failing tests is more helpful than the current
one. E.g. if the assertion from above fails it prints an error like

    Expecting:
      <[workflow-scm-step 2.4]>
    to contain exactly in any order:
      <[workflow-scm-step 2.4, workflow-step-api 2.20]>
    but could not find the following elements:
      <[workflow-step-api 2.20]>

so that it is immediately clear that one plugin is missing.