### PR TITLE
Only write cache files with valid JSON objects

### DIFF
--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/CacheManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/CacheManager.java
@@ -2,7 +2,7 @@ package io.jenkins.tools.pluginmanager.impl;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
+import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
@@ -11,6 +11,8 @@ import java.time.Duration;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.Files.newBufferedWriter;
 import static java.nio.file.Files.newInputStream;
 
 public class CacheManager {
@@ -43,10 +45,10 @@ public class CacheManager {
     }
 
 
-    void addToCache(String cacheKey, String value) {
-        try {
-            Path fileToCache = cache.resolve(cacheKey + ".json");
-            Files.write(fileToCache, value.getBytes(StandardCharsets.UTF_8));
+    void addToCache(String cacheKey, JSONObject value) {
+        Path fileToCache = cache.resolve(cacheKey + ".json");
+        try (Writer writer = newBufferedWriter(fileToCache, UTF_8)) {
+            value.write(writer);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -575,8 +575,9 @@ public class PluginManager {
         try {
             String urlText = IOUtils.toString(url, StandardCharsets.UTF_8);
             String result = removePossibleWrapperText(urlText);
-            cm.addToCache(cacheKey, result);
-            return new JSONObject(result);
+            JSONObject json = new JSONObject(result);
+            cm.addToCache(cacheKey, json);
+            return json;
         } catch (IOException e) {
             throw new UpdateCenterInfoRetrievalException("Error getting update center json", e);
         }

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/CacheManagerTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/CacheManagerTest.java
@@ -25,8 +25,12 @@ public class CacheManagerTest {
     @Test
     public void cacheReturnsJsonThatWasPutIntoCacheForSpecifiedKey() {
         CacheManager cacheManager = cacheManager();
-        cacheManager.addToCache("the-cache-key", "{\"value\":123}");
-        cacheManager.addToCache("another-cache-key", "{\"value\":456}");
+        cacheManager.addToCache(
+                "the-cache-key",
+                new JSONObject().put("value", 123));
+        cacheManager.addToCache(
+                "another-cache-key",
+                new JSONObject().put("value", 456));
 
         JSONObject jsonObject = cacheManager.retrieveFromCache("the-cache-key");
 
@@ -37,8 +41,12 @@ public class CacheManagerTest {
     @Test
     public void cacheReturnsLatestJsonThatWasPutIntoCacheForSpecifiedKey() {
         CacheManager cacheManager = cacheManager();
-        cacheManager.addToCache("the-cache-key", "{\"value\":123}");
-        cacheManager.addToCache("the-cache-key", "{\"value\":456}");
+        cacheManager.addToCache(
+                "the-cache-key",
+                new JSONObject().put("value", 123));
+        cacheManager.addToCache(
+                "the-cache-key",
+                new JSONObject().put("value", 456));
 
         JSONObject jsonObject = cacheManager.retrieveFromCache("the-cache-key");
 
@@ -53,7 +61,9 @@ public class CacheManagerTest {
         writeInstance.createCache();
         CacheManager readInstance = new CacheManager(cacheFolder, !VERBOSE);
 
-        writeInstance.addToCache("the-cache-key", "{\"value\":123}");
+        writeInstance.addToCache(
+                "the-cache-key",
+                new JSONObject().put("value", 123));
         JSONObject jsonObject = readInstance.retrieveFromCache("the-cache-key");
 
         assertThat(jsonObject.toMap())
@@ -71,7 +81,7 @@ public class CacheManagerTest {
     public void cacheReturnsNullWhenJsonWasPutIntoCacheMoreThanAnHourAgo() {
         CacheManager managerWithExpiredEntries = cacheManagerWithExpiredEntries();
 
-        managerWithExpiredEntries.addToCache("the-cache-key", "{\"value\":123}");
+        managerWithExpiredEntries.addToCache("the-cache-key", new JSONObject());
 
         JSONObject jsonObject = managerWithExpiredEntries.retrieveFromCache("the-cache-key");
 
@@ -91,7 +101,7 @@ public class CacheManagerTest {
     public void infoAboutAnExpiredCacheEntryIsWrittenToSystemOut() throws Exception {
         CacheManager managerWithExpiredEntries = cacheManagerWithExpiredEntries();
 
-        managerWithExpiredEntries.addToCache("the-cache-key", "{\"value\":123}");
+        managerWithExpiredEntries.addToCache("the-cache-key", new JSONObject());
 
         String out = tapSystemOutNormalized(
                 () -> managerWithExpiredEntries.retrieveFromCache("the-cache-key")


### PR DESCRIPTION
Avoid that the cache is poisoned. This may happen if PluginManager is
called with an URL that doesn't return valid JSON, e.g. an error page.