### PR TITLE
Remove unneeded additional CI (windows java8)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,6 @@
 // the only feature that buildPlugin has that relates to plugins is allowing you to test against multiple jenkins versions
 buildPlugin(configurations: [
         [ platform: "linux", jdk: "8", jenkins: null ],
-        [ platform: "windows", jdk: "8", jenkins: null ],
         [ platform: "linux", jdk: "11", jenkins: null, javaLevel: "8" ],
         [ platform: "windows", jdk: "11", jenkins: null, javaLevel: "8" ]
     ])


### PR DESCRIPTION
We test on java 11 with windows, highly unlikely to hit an issue there. buildPlugin() defaults don't use this configuration anymore.