### PR TITLE
Remove '/download' subpath for JENKINS_UC_DOWNLOAD

### DIFF
--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -911,7 +911,7 @@ public class PluginManager {
 
         String jenkinsUcDownload =  System.getenv("JENKINS_UC_DOWNLOAD");
         if (StringUtils.isNotEmpty(jenkinsUcDownload)) {
-            urlString = appendPathOntoUrl(jenkinsUcDownload, "/download/plugins", pluginName, pluginVersion, pluginName + ".hpi");
+            urlString = appendPathOntoUrl(jenkinsUcDownload, "/plugins", pluginName, pluginVersion, pluginName + ".hpi");
         } else if (StringUtils.isNotEmpty(pluginUrl)) {
             urlString = pluginUrl;
         } else if ((pluginVersion.equals("latest") || plugin.isLatest()) && !StringUtils.isEmpty(jenkinsUcLatest)) {


### PR DESCRIPTION
This change allows to use repositories/urls without 'download' subpath.
For example, mirrors like
- http://archives.jenkins-ci.org/plugins/
- https://mirror.xmission.com/jenkins/plugins/
- http://ftp-chi.osuosl.org/pub/jenkins/plugins/

**The same behaviour is implemented in install-plugins.sh**
https://github.com/jenkinsci/docker/blob/master/install-plugins.sh#L105