### PR TITLE
Fixes #214 by emptying the ref dir instead of deleting it

### DIFF
--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -127,11 +127,7 @@ public class PluginManager {
                 File[] toBeDeleted = refDir.listFiles();
                 if (toBeDeleted != null) {
                     for (File deletableFile : toBeDeleted) {
-                        if (deletableFile.isDirectory()) {
-                            FileUtils.deleteDirectory(deletableFile);
-                        } else {
-                            deletableFile.delete();
-                        }
+                        FileUtils.forceDelete(deletableFile);
                     }
                 }
             } catch (IOException e) {

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -125,11 +125,13 @@ public class PluginManager {
         if (refDir.exists()) {
             try {
                 File[] toBeDeleted = refDir.listFiles();
-                for (File deletableFile : toBeDeleted) {
-                    if (deletableFile.isDirectory()) {
-                        FileUtils.deleteDirectory(deletableFile);
-                    } else {
-                        deletableFile.delete();
+                if (toBeDeleted != null) {
+                    for (File deletableFile : toBeDeleted) {
+                        if (deletableFile.isDirectory()) {
+                            FileUtils.deleteDirectory(deletableFile);
+                        } else {
+                            deletableFile.delete();
+                        }
                     }
                 }
             } catch (IOException e) {

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -124,7 +124,14 @@ public class PluginManager {
     public void start(boolean downloadUc) {
         if (refDir.exists()) {
             try {
-                FileUtils.deleteDirectory(refDir);
+                File[] toBeDeleted = refDir.listFiles();
+                for (File deletableFile : toBeDeleted) {
+                    if (deletableFile.isDirectory()) {
+                        FileUtils.deleteDirectory(deletableFile);
+                    } else {
+                        deletableFile.delete();
+                    }
+                }
             } catch (IOException e) {
                 throw new UncheckedIOException("Unable to delete: " + refDir.getAbsolutePath(), e);
             }


### PR DESCRIPTION
Because in docker when a directory is marked as a volume, it gets mounted into the container, which means it can't actually be deleted.