### PR TITLE
Make --list do nothing for now

### DIFF
--- a/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/Main.java
+++ b/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/Main.java
@@ -67,6 +67,12 @@ public class Main {
                 return;
             }
 
+            if (cfg.isShowPluginsToBeDownloaded()) {
+                System.out.println("The --list flag is currently unsafe and is temporarily disabled, " +
+                    "see https://github.com/jenkinsci/plugin-installation-manager-tool/issues/173");
+                return;
+            }
+
             pm.start();
         } catch (Exception e) {
             if (options.isVerbose()) {


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/plugin-installation-manager-tool/issues/173

I'll hopefully get around to fixing this properly but for now let's remove this dangerous option

Created an issue for implementing this properly: https://github.com/jenkinsci/plugin-installation-manager-tool/issues/227