### PR TITLE
Adapt action to new syntax

### DIFF
--- a/.github/workflows/publish-release-artifact.yml
+++ b/.github/workflows/publish-release-artifact.yml
@@ -19,8 +19,6 @@ jobs:
         run: |
           version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           echo "::set-output name=project-version::$version"
-          echo "::set-env name=PROJECT_VERSION::$version"
-      - run: echo $PROJECT_VERSION
       - name: Fetch artifact
         id: fetch-artifact
         run: |
@@ -28,6 +26,7 @@ jobs:
           ARTIFACT_ID=plugin-management-cli
           FILE_NAME=jenkins-plugin-manager
           PROJECT_VERSION=${{ steps.set-version.outputs.project-version }}
+          echo $PROJECT_VERSION
           echo "::set-output name=file-name::$FILE_NAME"
           wget -q https://repo.jenkins-ci.org/releases/$GROUP_ID/$ARTIFACT_ID/$PROJECT_VERSION/$ARTIFACT_ID-$PROJECT_VERSION.jar \
             -O $FILE_NAME-$PROJECT_VERSION.jar


### PR DESCRIPTION
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/