### PR TITLE
Change explicitly defined plugin URL to override JENKINS_UC_DOWNLOAD

### DIFF
--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -914,10 +914,10 @@ public class PluginManager {
         }
 
         String jenkinsUcDownload =  System.getenv("JENKINS_UC_DOWNLOAD");
-        if (StringUtils.isNotEmpty(jenkinsUcDownload)) {
-            urlString = appendPathOntoUrl(jenkinsUcDownload, "/plugins", pluginName, pluginVersion, pluginName + ".hpi");
-        } else if (StringUtils.isNotEmpty(pluginUrl)) {
+        if (StringUtils.isNotEmpty(pluginUrl)) {
             urlString = pluginUrl;
+        } else if (StringUtils.isNotEmpty(jenkinsUcDownload)) {
+            urlString = appendPathOntoUrl(jenkinsUcDownload, "/plugins", pluginName, pluginVersion, pluginName + ".hpi");
         } else if ((pluginVersion.equals("latest") || plugin.isLatest()) && !StringUtils.isEmpty(jenkinsUcLatest)) {
             JSONObject plugins = latestUcJson.getJSONObject("plugins");
             if (plugins.has(plugin.getName())) {


### PR DESCRIPTION
If a user has specified an explicit plugin URL then that should take
precedence over JENKINS_UC_DOWNLOAD being defined. Otherwise, the
explicitly defined plugin URL will be overridden by the
JENKINS_UC_DOWNLOAD path.