### PR TITLE
Stop cleaning the plugin directory by default, add an opt-in flag for doing so

### DIFF
--- a/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/CliOptions.java
+++ b/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/CliOptions.java
@@ -39,6 +39,11 @@ class CliOptions {
             handler = FileOptionHandler.class)
     private File pluginDir;
 
+    @Option(name = "--clean-download-directory",
+            usage = "If sets, cleans the plugin download directory before plugin installation. " +
+                    "Otherwise the tool performs plugin download and reports compatibility issues, if any.")
+    private boolean cleanPluginDir;
+
     @Option(name = "--plugins", aliases = {"-p"}, usage = "List of plugins to install, separated by a space",
             handler = StringArrayOptionHandler.class)
     private String[] plugins = new String[0];
@@ -144,6 +149,7 @@ class CliOptions {
         return Config.builder()
                 .withPlugins(getPlugins())
                 .withPluginDir(getPluginDir())
+                .withCleanPluginsDir(isCleanPluginDir())
                 .withJenkinsUc(getUpdateCenter())
                 .withJenkinsUcExperimental(getExperimentalUpdateCenter())
                 .withJenkinsIncrementalsRepoMirror(getIncrementalsMirror())
@@ -212,6 +218,10 @@ class CliOptions {
                     "Will use default of " + Settings.DEFAULT_PLUGIN_DIR_LOCATION);
         }
         return new File(Settings.DEFAULT_PLUGIN_DIR_LOCATION);
+    }
+
+    public boolean isCleanPluginDir() {
+        return cleanPluginDir;
     }
 
     @CheckForNull

--- a/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/Main.java
+++ b/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/Main.java
@@ -67,12 +67,6 @@ public class Main {
                 return;
             }
 
-            if (cfg.isShowPluginsToBeDownloaded()) {
-                System.out.println("The --list flag is currently unsafe and is temporarily disabled, " +
-                    "see https://github.com/jenkinsci/plugin-installation-manager-tool/issues/173");
-                return;
-            }
-
             pm.start();
         } catch (Exception e) {
             if (options.isVerbose()) {

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Config.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Config.java
@@ -20,6 +20,7 @@ import javax.annotation.CheckForNull;
  */
 public class Config {
     private File pluginDir;
+    private boolean cleanPluginDir;
     private boolean showWarnings;
     private boolean showAllWarnings;
     private boolean showAvailableUpdates;
@@ -49,6 +50,7 @@ public class Config {
 
     private Config(
             File pluginDir,
+            boolean cleanPluginDir,
             boolean showWarnings,
             boolean showAllWarnings,
             boolean showAvailableUpdates,
@@ -67,6 +69,7 @@ public class Config {
             boolean skipFailedPlugins,
             OutputFormat outputFormat) {
         this.pluginDir = pluginDir;
+        this.cleanPluginDir = cleanPluginDir;
         this.showWarnings = showWarnings;
         this.showAllWarnings = showAllWarnings;
         this.showAvailableUpdates = showAvailableUpdates;
@@ -88,6 +91,10 @@ public class Config {
 
     public File getPluginDir() {
         return pluginDir;
+    }
+
+    public boolean isCleanPluginDir() {
+        return cleanPluginDir;
     }
 
     public boolean isShowWarnings() {
@@ -165,6 +172,7 @@ public class Config {
 
     public static class Builder {
         private File pluginDir;
+        private boolean cleanPluginDir;
         private boolean showWarnings;
         private boolean showAllWarnings;
         private boolean showAvailableUpdates;
@@ -188,6 +196,11 @@ public class Config {
 
         public Builder withPluginDir(File pluginDir) {
             this.pluginDir = pluginDir;
+            return this;
+        }
+
+        public Builder withCleanPluginsDir(boolean cleanPluginDir) {
+            this.cleanPluginDir = cleanPluginDir;
             return this;
         }
 
@@ -284,6 +297,7 @@ public class Config {
         public Config build() {
             return new Config(
                     pluginDir,
+                    cleanPluginDir,
                     showWarnings,
                     showAllWarnings,
                     showAvailableUpdates,

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -511,9 +511,9 @@ public class PluginManager {
                 Files.move(downloadedPlugin.toPath(), new File(pluginDir, archiveName).toPath(), StandardCopyOption.REPLACE_EXISTING);
             } catch (IOException ex) {
                 if (skipFailedPlugins) {
-                    System.out.println("SKIP: Unable to copy " + plugin.getName() + " to the plugin directory");
+                    System.out.println("SKIP: Unable to move" + plugin.getName() + " to the plugin directory");
                 } else {
-                    throw new DownloadPluginException("Unable to copy " + plugin.getName()  + " to the plugin directory", ex);
+                    throw new DownloadPluginException("Unable to move" + plugin.getName()  + " to the plugin directory", ex);
                 }
             }
         }

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -134,7 +134,7 @@ public class PluginManager {
      * @since TODO
      */
     public void start(boolean downloadUc) {
-        if (cfg.isCleanPluginDir() &&  pluginDir.exists()) {
+        if (cfg.isCleanPluginDir() && pluginDir.exists()) {
             try {
                 logVerbose("Cleaning up the target plugin directory: " + pluginDir);
                 File[] toBeDeleted = pluginDir.listFiles();

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -493,7 +493,8 @@ public class PluginManager {
         final List<Plugin> failedPlugins = getFailedPlugins();
         if (!skipFailedPlugins && failedPlugins.size() > 0) {
             throw new DownloadPluginException("Some plugin downloads failed: " +
-                    failedPlugins.stream().map(Plugin::getName).collect(Collectors.joining(",")));
+                    failedPlugins.stream().map(Plugin::getName).collect(Collectors.joining(",")) +
+                    ". See " + downloadsTmpDir.getAbsolutePath() + " for the temporary download directory");
         }
         Set<String> failedPluginNames = new HashSet<>(failedPlugins.size());
         failedPlugins.forEach(plugin -> failedPluginNames.add(plugin.getName()));
@@ -504,8 +505,8 @@ public class PluginManager {
             File downloadedPlugin = new File(downloadsTmpDir, archiveName);
             try {
                 if (failedPluginNames.contains(plugin.getName())) {
-                    System.out.println("Will skip the failed plugin download: " + plugin.getName());
-                    Files.deleteIfExists(downloadedPlugin.toPath());
+                    System.out.println("Will skip the failed plugin download: " + plugin.getName() +
+                            ". See " + downloadedPlugin.getAbsolutePath() + " for the downloaded file");
                 }
                 // We do not double-check overrides here, because findPluginsToDownload() has already done it
                 Files.move(downloadedPlugin.toPath(), new File(pluginDir, archiveName).toPath(), StandardCopyOption.REPLACE_EXISTING);
@@ -1226,7 +1227,7 @@ public class PluginManager {
      */
     @Deprecated
     public String getAttributeFromManifest(File file, String key) {
-        return getAttributeFromManifest(file, key);
+        return ManifestTools.getAttributeFromManifest(file, key);
     }
 
     /**

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -508,7 +508,7 @@ public class PluginManager {
                     Files.deleteIfExists(downloadedPlugin.toPath());
                 }
                 // We do not double-check overrides here, because findPluginsToDownload() has already done it
-                Files.copy(downloadedPlugin.toPath(), new File(pluginDir, archiveName).toPath(), StandardCopyOption.REPLACE_EXISTING);
+                Files.move(downloadedPlugin.toPath(), new File(pluginDir, archiveName).toPath(), StandardCopyOption.REPLACE_EXISTING);
             } catch (IOException ex) {
                 if (skipFailedPlugins) {
                     System.out.println("SKIP: Unable to copy " + plugin.getName() + " to the plugin directory");

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -762,13 +762,13 @@ public class PluginManager {
 
             if (plugin.getVersion().toString().equals("latest") ||
                     plugin.getVersion().toString().equals("experimental")) {
-                String version = ManifestTools.getAttributeFromManifest(tempFile, "Plugin-Version");
+                String version = getAttributeFromManifest(tempFile, "Plugin-Version");
                 if (!StringUtils.isEmpty(version)) {
                     plugin.setVersion(new VersionNumber(version));
                 }
             }
 
-            String dependencyString = ManifestTools.getAttributeFromManifest(tempFile, "Plugin-Dependencies");
+            String dependencyString = getAttributeFromManifest(tempFile, "Plugin-Dependencies");
 
             //not all plugin Manifests contain the Plugin-Dependencies field
             if (StringUtils.isEmpty(dependencyString)) {
@@ -800,7 +800,7 @@ public class PluginManager {
                                     .map(p -> p.getName() + " " + p.getVersion())
                                     .collect(Collectors.joining("\n")));
 
-            plugin.setJenkinsVersion(ManifestTools.getAttributeFromManifest(tempFile, "Jenkins-Version"));
+            plugin.setJenkinsVersion(getAttributeFromManifest(tempFile, "Jenkins-Version"));
             Files.delete(tempFile.toPath());
             return dependentPlugins;
         } catch (IOException e) {
@@ -1197,7 +1197,7 @@ public class PluginManager {
             System.out.println("Unable to get Jenkins version from the WAR file: WAR file path is not defined.");
             return null;
         }
-        String version = ManifestTools.getAttributeFromManifest(jenkinsWarFile, "Jenkins-Version");
+        String version = getAttributeFromManifest(jenkinsWarFile, "Jenkins-Version");
         if (StringUtils.isEmpty(version)) {
             System.out.println("Unable to get Jenkins version from the WAR file " + jenkinsWarFile.getPath());
             return null;
@@ -1213,7 +1213,7 @@ public class PluginManager {
      * @return plugin version
      */
     public String getPluginVersion(File file) {
-        String version = ManifestTools.getAttributeFromManifest(file, "Plugin-Version");
+        String version = getAttributeFromManifest(file, "Plugin-Version");
         if (StringUtils.isEmpty(version)) {
             System.out.println("Unable to get plugin version from " + file);
             return "";
@@ -1226,7 +1226,7 @@ public class PluginManager {
      */
     @Deprecated
     public String getAttributeFromManifest(File file, String key) {
-        return ManifestTools.getAttributeFromManifest(file, key);
+        return getAttributeFromManifest(file, key);
     }
 
     /**

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -512,9 +512,9 @@ public class PluginManager {
                 Files.move(downloadedPlugin.toPath(), new File(pluginDir, archiveName).toPath(), StandardCopyOption.REPLACE_EXISTING);
             } catch (IOException ex) {
                 if (skipFailedPlugins) {
-                    System.out.println("SKIP: Unable to move" + plugin.getName() + " to the plugin directory");
+                    System.out.println("SKIP: Unable to move " + plugin.getName() + " to the plugin directory");
                 } else {
-                    throw new DownloadPluginException("Unable to move" + plugin.getName()  + " to the plugin directory", ex);
+                    throw new DownloadPluginException("Unable to move " + plugin.getName()  + " to the plugin directory", ex);
                 }
             }
         }

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/util/ManifestTools.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/util/ManifestTools.java
@@ -3,8 +3,6 @@ package io.jenkins.tools.pluginmanager.util;
 import hudson.util.VersionNumber;
 import io.jenkins.tools.pluginmanager.impl.DownloadPluginException;
 import io.jenkins.tools.pluginmanager.impl.Plugin;
-import org.apache.commons.lang3.StringUtils;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -12,12 +10,13 @@ import java.util.List;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
+import org.apache.commons.lang3.StringUtils;
 
 public class ManifestTools {
 
     public static Plugin readPluginFromFile(File file) throws IOException {
         Plugin plugin = new Plugin(file.getName(), "undefined", null, null);
-        List<Plugin> dependentPlugins = new ArrayList<>();
+
 
         // TODO: refactor code so that we read the manifest only once
         String version = getAttributeFromManifest(file, "Plugin-Version");
@@ -34,6 +33,7 @@ public class ManifestTools {
         }
 
         String[] dependencies = dependencyString.split(",");
+        List<Plugin> dependentPlugins = new ArrayList<>();
         for (String dependency : dependencies) {
             if (!dependency.contains("resolution:=optional")) {
                 String[] pluginInfo = dependency.split(":");
@@ -44,6 +44,7 @@ public class ManifestTools {
                 dependentPlugin.setParent(plugin);
             }
         }
+        plugin.setDependencies(dependentPlugins);
 
         return plugin;
     }

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/util/ManifestTools.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/util/ManifestTools.java
@@ -1,0 +1,73 @@
+package io.jenkins.tools.pluginmanager.util;
+
+import hudson.util.VersionNumber;
+import io.jenkins.tools.pluginmanager.impl.DownloadPluginException;
+import io.jenkins.tools.pluginmanager.impl.Plugin;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+
+public class ManifestTools {
+
+    public static Plugin readPluginFromFile(File file) throws IOException {
+        Plugin plugin = new Plugin(file.getName(), "undefined", null, null);
+        List<Plugin> dependentPlugins = new ArrayList<>();
+
+        // TODO: refactor code so that we read the manifest only once
+        String version = getAttributeFromManifest(file, "Plugin-Version");
+        if (!StringUtils.isEmpty(version)) {
+            plugin.setVersion(new VersionNumber(version));
+        }
+        plugin.setJenkinsVersion(getAttributeFromManifest(file, "Jenkins-Version"));
+
+
+        String dependencyString = getAttributeFromManifest(file, "Plugin-Dependencies");
+        if (StringUtils.isEmpty(dependencyString)) {
+            // not all plugin Manifests contain the Plugin-Dependencies field
+            return plugin;
+        }
+
+        String[] dependencies = dependencyString.split(",");
+        for (String dependency : dependencies) {
+            if (!dependency.contains("resolution:=optional")) {
+                String[] pluginInfo = dependency.split(":");
+                String pluginName = pluginInfo[0];
+                String pluginVersion = pluginInfo[1];
+                Plugin dependentPlugin = new Plugin(pluginName, pluginVersion, null, null);
+                dependentPlugins.add(dependentPlugin);
+                dependentPlugin.setParent(plugin);
+            }
+        }
+
+        return plugin;
+    }
+
+    /**
+     * Given a jar file and a key to retrieve from the jar's MANIFEST.MF file, confirms that the file is a jar returns
+     * the value matching the key
+     *
+     * @param file jar file to get manifest from
+     * @param key  key matching value to retrieve
+     * @return value matching the key in the jar file
+     */
+    public static String getAttributeFromManifest(File file, String key) {
+        try (JarFile jarFile = new JarFile(file)) {
+            Manifest manifest = jarFile.getManifest();
+            Attributes attributes = manifest.getMainAttributes();
+            return attributes.getValue(key);
+        } catch (IOException e) {
+            System.out.println("Unable to open " + file);
+            if (key.equals("Plugin-Dependencies")) {
+                throw new DownloadPluginException("Unable to determine plugin dependencies", e);
+            }
+        }
+        return null;
+    }
+
+}

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerIntegrationTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerIntegrationTest.java
@@ -195,7 +195,6 @@ public class PluginManagerIntegrationTest {
         assertThatNoException();
     }
 
-
     @Test
     public void verifyDownloads_smoke() throws Exception {
 

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerIntegrationTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerIntegrationTest.java
@@ -1,6 +1,7 @@
 package io.jenkins.tools.pluginmanager.impl;
 
 import io.jenkins.tools.pluginmanager.config.Config;
+import io.jenkins.tools.pluginmanager.util.ManifestTools;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -13,8 +14,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
-
-import io.jenkins.tools.pluginmanager.util.ManifestTools;
 import org.apache.commons.io.IOUtils;
 import org.json.JSONObject;
 import org.junit.BeforeClass;

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerIntegrationTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerIntegrationTest.java
@@ -17,6 +17,7 @@ import org.apache.commons.io.IOUtils;
 import org.json.JSONObject;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
@@ -190,5 +191,31 @@ public class PluginManagerIntegrationTest {
         // then
         pluginManager.findPluginsAndDependencies(requestedPlugins);
         assertThatNoException();
+    }
+
+    //TODO: Enable as auto-test once it can run without massive traffic overhead
+    @Test
+    @Ignore
+    public void verifyDownloads() throws Exception {
+
+        // First cycle, empty dir
+        List<Plugin> requestedPlugins_1 = new ArrayList<>(Arrays.asList(
+                new Plugin("workflow-job", "2.39", null, null)
+        ));
+        PluginManager pluginManager = initPluginManager(
+                configBuilder -> configBuilder.withPlugins(requestedPlugins_1));
+        pluginManager.start();
+
+        // Second cycle
+        List<Plugin> requestedPlugins_2 = new ArrayList<>(Arrays.asList(
+                new Plugin("workflow-job", "2.40", null, null),
+                new Plugin("pipeline-utility-steps", "2.6.1", null, null)
+        ));
+        PluginManager pluginManager2 = initPluginManager(
+                configBuilder -> configBuilder.withPlugins(requestedPlugins_2));
+        pluginManager2.start();
+
+
+        Plugin
     }
 }

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerIntegrationTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerIntegrationTest.java
@@ -196,10 +196,39 @@ public class PluginManagerIntegrationTest {
         assertThatNoException();
     }
 
-    //TODO: Enable as auto-test once it can run without massive traffic overhead
+
+    @Test
+    public void verifyDownloads_smoke() throws Exception {
+
+        // First cycle, empty dir
+        Plugin initialTrileadAPI = new Plugin("trilead-api", "1.0.12", null, null);
+        List<Plugin> requestedPlugins_1 = new ArrayList<>(Arrays.asList(
+                initialTrileadAPI
+        ));
+        PluginManager pluginManager = initPluginManager(
+                configBuilder -> configBuilder.withPlugins(requestedPlugins_1).withDoDownload(true));
+        pluginManager.start();
+        assertPluginInstalled(initialTrileadAPI);
+
+        // Second cycle, with plugin update and new plugin installation
+        Plugin trileadAPI = new Plugin("trilead-api", "1.0.13", null, null);
+        Plugin snakeYamlAPI = new Plugin("snakeyaml-api", "1.27.0", null, null);
+        List<Plugin> requestedPlugins_2 = new ArrayList<>(Arrays.asList(
+                trileadAPI, snakeYamlAPI
+        ));
+        PluginManager pluginManager2 = initPluginManager(
+                configBuilder -> configBuilder.withPlugins(requestedPlugins_2).withDoDownload(true));
+        pluginManager2.start();
+
+        // Ensure that the plugins are actually in place
+        assertPluginInstalled(trileadAPI);
+        assertPluginInstalled(snakeYamlAPI);
+    }
+
+    //TODO: Enable as auto-test once it can run without big traffic overhead (15 plugin downloads)
     @Test
     @Ignore
-    public void verifyDownloads() throws Exception {
+    public void verifyDownloads_withDependencies() throws Exception {
 
         // First cycle, empty dir
         Plugin initialWorkflowJob = new Plugin("workflow-job", "2.39", null, null);

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerIntegrationTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerIntegrationTest.java
@@ -203,7 +203,7 @@ public class PluginManagerIntegrationTest {
                 new Plugin("workflow-job", "2.39", null, null)
         ));
         PluginManager pluginManager = initPluginManager(
-                configBuilder -> configBuilder.withPlugins(requestedPlugins_1));
+                configBuilder -> configBuilder.withPlugins(requestedPlugins_1).withDoDownload(true));
         pluginManager.start();
 
         // Second cycle
@@ -214,8 +214,5 @@ public class PluginManagerIntegrationTest {
         PluginManager pluginManager2 = initPluginManager(
                 configBuilder -> configBuilder.withPlugins(requestedPlugins_2));
         pluginManager2.start();
-
-
-        Plugin
     }
 }

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerIntegrationTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerIntegrationTest.java
@@ -16,10 +16,10 @@ import java.util.zip.ZipFile;
 
 import io.jenkins.tools.pluginmanager.util.ManifestTools;
 import org.apache.commons.io.IOUtils;
-import org.hamcrest.CoreMatchers;
 import org.json.JSONObject;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
@@ -497,26 +497,6 @@ public class PluginManagerTest {
     }
 
     @Test
-    public void downloadPluginsSuccessfulTest() {
-        Config config = Config.builder()
-                .withJenkinsWar(Settings.DEFAULT_WAR)
-                .withPluginDir(new File(folder.getRoot(), "plugins"))
-                .build();
-
-        PluginManager pluginManager = new PluginManager(config);
-        PluginManager pluginManagerSpy = spy(pluginManager);
-
-        doReturn(true).when(pluginManagerSpy).downloadPlugin(any(Plugin.class), nullable(File.class));
-
-        List<Plugin> plugins = singletonList(
-                new Plugin("plugin", "1.0", null, null));
-
-        pluginManagerSpy.downloadPlugins(plugins);
-
-        assertThat(pluginManagerSpy.getFailedPlugins()).isEmpty();
-    }
-
-    @Test
     public void downloadPluginsUnsuccessfulTest() {
         Config config = Config.builder()
                 .withJenkinsWar(Settings.DEFAULT_WAR)

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
@@ -78,7 +78,7 @@ public class PluginManagerTest {
 
         PluginManager pluginManagerSpy = spy(pluginManager);
 
-        doNothing().when(pluginManagerSpy).createRefDir();
+        doNothing().when(pluginManagerSpy).createPluginDir(true);
         VersionNumber versionNumber = new VersionNumber("2.182");
         doReturn(versionNumber).when(pluginManagerSpy).getJenkinsVersionFromWar();
         doNothing().when(pluginManagerSpy).getUCJson(versionNumber);


### PR DESCRIPTION
After https://github.com/jenkinsci/plugin-installation-manager-tool/pull/94 , the plugin directory was always emptied before downloading the plugins. This patch makes the plugin dir cleaning an optional behavior.

Sample output on a second run:

```
structs has no dependencies
Version of script-security (1.39) required by workflow-support (3.4) is lower than the version required (1.46) by pipeline-utility-steps (2.6.1), upgrading required plugin version
Installed version (1.18) of structs is less than minimum required version of 1.20, bundled plugin will be upgraded
Installed version (1.39) of script-security is less than minimum required version of 1.46, bundled plugin will be upgraded
Installed version (3.3) of workflow-support is less than minimum required version of 3.4, bundled plugin will be upgraded
Installed version (2.20) of workflow-step-api is less than minimum required version of 2.22, bundled plugin will be upgraded
Installed version (2.36) of workflow-api is less than minimum required version of 2.40, bundled plugin will be upgraded
Installed version (2.39) of workflow-job is less than minimum required version of 2.40, bundled plugin will be upgraded
Done
```

