### PR TITLE
Ensure that the Jenkins core versions requirements are properly checked for plugins without dependencies

### DIFF
--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -787,6 +787,7 @@ public class PluginManager {
                     plugin.setVersion(new VersionNumber(version));
                 }
             }
+            plugin.setJenkinsVersion(getAttributeFromManifest(tempFile, "Jenkins-Version"));
 
             String dependencyString = getAttributeFromManifest(tempFile, "Plugin-Dependencies");
 
@@ -820,7 +821,6 @@ public class PluginManager {
                                     .map(p -> p.getName() + " " + p.getVersion())
                                     .collect(Collectors.joining("\n")));
 
-            plugin.setJenkinsVersion(getAttributeFromManifest(tempFile, "Jenkins-Version"));
             Files.delete(tempFile.toPath());
             return dependentPlugins;
         } catch (IOException e) {


### PR DESCRIPTION
Just a minor bug I noticed why playing with plugin combinations