### PR TITLE
Add support for exploded plugin directories

### DIFF
--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/CacheManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/CacheManager.java
@@ -21,15 +21,25 @@ public class CacheManager {
     private Path cache;
     private boolean verbose;
     private Clock clock;
+    private boolean expires;
 
     public CacheManager(Path cache, boolean verbose) {
-        this(cache, verbose, Clock.systemDefaultZone());
+        this(cache, verbose, Clock.systemDefaultZone(), true);
+    }
+
+    public CacheManager(Path cache, boolean verbose, boolean expires) {
+        this(cache, verbose, Clock.systemDefaultZone(), expires);
     }
 
     CacheManager(Path cache, boolean verbose, Clock clock) {
+        this(cache, verbose, clock, true);
+    }
+
+    CacheManager(Path cache, boolean verbose, Clock clock, boolean expires) {
         this.cache = cache;
         this.verbose = verbose;
         this.clock = clock;
+        this.expires = expires;
     }
 
     void createCache() {
@@ -78,9 +88,12 @@ public class CacheManager {
 
             if (betweenHours > 0L) {
                 if (verbose) {
-                    System.out.println("Cache entry expired");
+                    System.out.println("Cache entry expired: " + cacheKey +
+                            (expires ? ". Will skip it" : ". Will accept it, because expiration is disabled"));
                 }
-                return null;
+                if (expires) {
+                    return null;
+                }
             }
 
             JSONTokener tokener = new JSONTokener(newInputStream(cachedPath));

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -523,7 +523,13 @@ public class PluginManager {
                             ". See " + downloadedPlugin.getAbsolutePath() + " for the downloaded file");
                 }
                 // We do not double-check overrides here, because findPluginsToDownload() has already done it
-                Files.move(downloadedPlugin.toPath(), new File(pluginDir, archiveName).toPath(), StandardCopyOption.REPLACE_EXISTING);
+                File finalPath = new File(pluginDir, archiveName);
+                if (finalPath.isDirectory()) {
+                    // Jenkins supports storing plugins as unzipped files with ".jpi" extension
+                    FileUtils.cleanDirectory(finalPath);
+                    Files.delete(finalPath.toPath());
+                }
+                Files.move(downloadedPlugin.toPath(), finalPath.toPath(), StandardCopyOption.REPLACE_EXISTING);
             } catch (IOException ex) {
                 if (skipFailedPlugins) {
                     System.out.println("SKIP: Unable to move " + plugin.getName() + " to the plugin directory");

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/util/PluginManagerUtils.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/util/PluginManagerUtils.java
@@ -1,19 +1,17 @@
 package io.jenkins.tools.pluginmanager.util;
 
-import org.apache.commons.io.IOUtils;
-
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.FileSystems;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Enumeration;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.commons.io.IOUtils;
 
 import static java.util.Objects.requireNonNull;
 
@@ -152,6 +150,7 @@ public final class PluginManagerUtils {
      * @param source Source file
      * @param destDir Destination
      */
+    @SuppressFBWarnings("PATH_TRAVERSAL_IN")
     public static File explodePlugin(File source, File destDir) throws IOException {
         try (JarFile jarfile = new JarFile(source)) {
             Enumeration<JarEntry> entries = jarfile.entries();

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/util/PluginManagerUtils.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/util/PluginManagerUtils.java
@@ -1,5 +1,17 @@
 package io.jenkins.tools.pluginmanager.util;
 
+import org.apache.commons.io.IOUtils;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Enumeration;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -133,6 +145,34 @@ public final class PluginManagerUtils {
         } while (!urlString.equals(lastUrlString));
 
         return urlString;
+    }
+
+    /**
+     * Explodes the plugin archive.
+     * @param source Source file
+     * @param destDir Destination
+     */
+    public static File explodePlugin(File source, File destDir) throws IOException {
+        try (JarFile jarfile = new JarFile(source)) {
+            Enumeration<JarEntry> entries = jarfile.entries();
+            while (entries.hasMoreElements()) {
+                JarEntry je = entries.nextElement();
+                File file = new File(destDir, je.getName());
+                if (!file.exists()) {
+                    Files.createDirectories(file.getParentFile().toPath());
+                    file = new File(destDir, je.getName());
+                }
+                if (je.isDirectory()) {
+                    continue;
+                }
+
+                try (InputStream is = jarfile.getInputStream(je);
+                     FileOutputStream fo = new FileOutputStream(file)) {
+                    IOUtils.copy(is, fo);
+                }
+            }
+            return destDir;
+        }
     }
 
 }

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/CacheManagerTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/CacheManagerTest.java
@@ -114,7 +114,7 @@ public class CacheManagerTest {
                 () -> managerWithExpiredEntries.retrieveFromCache("the-cache-key")
         );
 
-         assertThat(out).isEqualTo("Cache entry expired\n");
+         assertThat(out).isEqualTo("Cache entry expired: the-cache-key. Will skip it\n");
     }
 
     @Test


### PR DESCRIPTION
It is not very documented, but Jenkins supports `plugins/foobar.jpi` directories in addition to archives. This allows to improve startup performance in some cases. 

This patch does not add support for exploding plugin archives, but it makes the tool compatible with the plugins which are already exploded.