### PR TITLE
Fix typo in PluginManager.java

### DIFF
--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -1164,7 +1164,7 @@ public class PluginManager {
         String expectedChecksum = plugin.getSha256Checksum();
         if (expectedChecksum == null) {
             if (verbose) {
-                System.out.println("No checksum found for " + plugin.getName() + " (probably custom built plugin");
+                System.out.println("No checksum found for " + plugin.getName() + " (probably custom built plugin)");
             }
             return;
         }


### PR DESCRIPTION
Trivial modification but since we use a lot of custom built plugins it was really annoying to see it each time