### PR TITLE
Provide JENKINS_UC_DOWNLOAD2 to be used as is without hardcoding "/plugins"

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,10 @@ Jenkins in a broken state.
 * `CACHE_DIR`: used to configure the directory where the plugins update center cache is located. By default it will be in `~/.cache/jenkins-plugin-management-cli`,
 if the user doesn't have a home directory when it will go to: `$(pwd)/.cache/jenkins-plugin-management-cli`.
 
-* `JENKINS_UC_DOWNLOAD`: used to configure the URL from where plugins will be downloaded from. Often used to cache or to proxy the Jenkins plugin download site. 
-If set then all plugins will be downloaded through that URL.
-  
+* `JENKINS_UC_DOWNLOAD`: when this value is set, it replaces the plugin download URL found in the `update-center.json` file with `${JENKINS_UC_DOWNLOAD}+/plugins`. Often used to cache or to proxy the Jenkins plugin download site. To also replace the `/plugins` hard coded value, use `JENKINS_UC_DOWNLOAD2`.
+
+* `JENKINS_UC_DOWNLOAD2`: when this value is set, it replaces the plugin download URL found in the `update-center.json` file with `JENKINS_UC_DOWNLOAD2`. Often used to cache or to proxy the Jenkins plugin download site. When this value is set at the same time as `JENKINS_UC_DOWNLOAD`, the later is ignored.
+
 #### Plugin Input Format
 The expected format for plugins in the .txt file or entered through the `--plugins` CLI option is `artifact ID:version` or `artifact ID:url` or `artifact:version:url`
 

--- a/plugin-management-library/pom.xml
+++ b/plugin-management-library/pom.xml
@@ -70,6 +70,12 @@
           <version>2.27.2</version>
           <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-rules</artifactId>
+            <version>1.19.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -1027,7 +1027,10 @@ public class PluginManager {
         }
 
         String jenkinsUcDownload =  System.getenv("JENKINS_UC_DOWNLOAD");
-        if (StringUtils.isNotEmpty(pluginUrl)) {
+        String jenkinsUcDownload2 =  System.getenv("JENKINS_UC_DOWNLOAD2");
+        if (StringUtils.isNotEmpty(jenkinsUcDownload2)) {
+            urlString = appendPathOntoUrl(jenkinsUcDownload2, pluginName, pluginVersion, pluginName + ".hpi");
+        } else if (StringUtils.isNotEmpty(pluginUrl)) {
             urlString = pluginUrl;
         } else if (StringUtils.isNotEmpty(jenkinsUcDownload)) {
             urlString = appendPathOntoUrl(jenkinsUcDownload, "/plugins", pluginName, pluginVersion, pluginName + ".hpi");

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
@@ -20,6 +20,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.rules.TemporaryFolder;
 
 import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemOutNormalized;
@@ -38,6 +39,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+
 public class PluginManagerTest {
     private PluginManager pm;
     private Config cfg;
@@ -45,6 +47,9 @@ public class PluginManagerTest {
 
     @Rule
     public final TemporaryFolder folder = new TemporaryFolder();
+
+    @Rule
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
     @Before
     public void setUp() {
@@ -1012,6 +1017,10 @@ public class PluginManagerTest {
         String otherURL = dirName(cfg.getJenkinsUc().toString()) +
                 "download/plugins/pluginName/otherversion/pluginName.hpi";
         assertThat(pm.getPluginDownloadUrl(pluginOtherVersion)).isEqualTo(otherURL);
+
+        Plugin pluginUrlOverride = new Plugin("pluginName", "pluginVersion", "https://mirror.server.com/path/pluginName/pluginVersion/pluginName.hpi", null);
+        environmentVariables.set("JENKINS_UC_DOWNLOAD2", "https://server.com/jenkins-plugins");
+        assertThat(pm.getPluginDownloadUrl(plugin)).isEqualTo("https://server.com/jenkins-plugins/pluginName/pluginVersion/pluginName.hpi");
     }
 
     @Test


### PR DESCRIPTION
The `JENKINS_UC_DOWNLOAD2` env var is used as is when substituting the plugin URL, contrary to the `JENKINS_UC_DOWNLOAD` env var which is always concatenated (followed) with the "/plugins" path.

For cases where the user does not control the path to the plugin on the mirror site, use `JENKINS_UC_DOWNLOAD2`.

This replaces PR #277 