### PR TITLE
chore: log the mirror that plugin is downloading from

### DIFF
--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -1115,6 +1115,7 @@ public class PluginManager {
                     List<URI> redirectLocations = context.getRedirectLocations();
                     // Expected to be an absolute URI
                     URI location = URIUtils.resolve(httphead.getURI(), target, redirectLocations);
+                    logVerbose(String.format("downloading %s from %s", plugin.getName(), location));
                     FileUtils.copyURLToFile(location.toURL(), pluginFile);
                 } catch (URISyntaxException | IOException e) {
                     logVerbose(String.format("Unable to resolve plugin URL %s, or download plugin %s to file",


### PR DESCRIPTION
I'm noticing that every now and again the I get plugin download issues but it's hard to tell which mirror is having issues.

This PR adds a log statement when running in verbose mode e.g.

```
downloading workflow-scm-step from https://mirror.gruenehoelle.nl/jenkins/plugins/workflow-scm-step/2.11/workflow-scm-step.hpi
```