### PR TITLE
Handle optional dependencies correctly - Fixes #286

### DIFF
--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/Plugin.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/Plugin.java
@@ -21,6 +21,7 @@ public class Plugin {
     private List<SecurityWarning> securityWarnings;
     private boolean latest;
     private boolean experimental;
+    private boolean optional;
     private String sha256Checksum;
     private VersionNumber jenkinsVersion;
 
@@ -134,6 +135,15 @@ public class Plugin {
         return parent;
     }
 
+    public Plugin setOptional(boolean optional) {
+        this.optional = optional;
+        return this;
+    }
+
+    public boolean getOptional() {
+        return this.optional;
+    }
+
     public VersionNumber getJenkinsVersion() {
         return jenkinsVersion;
     }
@@ -174,7 +184,8 @@ public class Plugin {
         return Objects.equals(name, plugin.name) &&
                 Objects.equals(version, plugin.version) &&
                 Objects.equals(groupId, plugin.groupId) &&
-                Objects.equals(url, plugin.url);
+                Objects.equals(url, plugin.url) &&
+                Objects.equals(optional, plugin.optional);
     }
 
     @Override

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -990,13 +990,19 @@ public class PluginManager {
 
                 if (!recursiveDependencies.containsKey(dependencyName)) {
                     recursiveDependencies.put(dependencyName, p);
-                    queue.add(p);
+                    if (!p.getOptional()) {
+                        // If/when this dependency becomes non-optional, we will expand its dependencies.
+                        queue.add(p);
+                    }
                 } else {
                     Plugin existingDependency = recursiveDependencies.get(dependencyName);
-                    if (existingDependency.getVersion().isOlderThan(p.getVersion())) {
-                        outputPluginReplacementInfo(existingDependency, p);
-                        queue.add(p); //in case the higher version contains dependencies the lower version didn't have
-                        recursiveDependencies.replace(dependencyName, existingDependency, p);
+                    Plugin newDependency = combineDependencies(existingDependency, p);
+                    if (!newDependency.equals(existingDependency)) {
+                        outputPluginReplacementInfo(existingDependency, newDependency);
+                        recursiveDependencies.replace(dependencyName, existingDependency, newDependency);
+                        // newDependency may have additional dependencies if it is a higher version or
+                        // if it became non-optional.
+                        queue.add(newDependency);
                     }
                 }
             }

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -954,7 +954,6 @@ public class PluginManager {
         return resolveRecursiveDependencies(plugin, null);
     }
 
-    // TODO(oleg_nenashev): This method is private, because it is only a partial fix for https://github.com/jenkinsci/plugin-installation-manager-tool/issues/101
     // A full dependency graph resolution and removal of non-needed dependency trees is required
     public Map<String, Plugin> resolveRecursiveDependencies(Plugin plugin, @CheckForNull Map<String, Plugin> topLevelDependencies) {
         Deque<Plugin> queue = new LinkedList<>();

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -577,14 +577,43 @@ public class PluginManager {
                     allPluginDependencies.put(dependencyName, dependentPlugin);
                 } else {
                     Plugin existingDependency = allPluginDependencies.get(dependencyName);
-                    if (existingDependency.getVersion().isOlderThan(dependencyVersion)) {
-                        outputPluginReplacementInfo(existingDependency, dependentPlugin);
-                        allPluginDependencies.replace(existingDependency.getName(), dependentPlugin);
-                    }
+                    allPluginDependencies.replace(existingDependency.getName(),
+                            combineDependencies(existingDependency, dependentPlugin));
                 }
             }
         }
-        return allPluginDependencies;
+        return removeOptional(allPluginDependencies);
+    }
+
+    private Map<String, Plugin> removeOptional(Map<String, Plugin> plugins) {
+        Map<String, Plugin> filtered = new HashMap<>();
+        for (Map.Entry<String, Plugin> entry : plugins.entrySet()) {
+            if (!entry.getValue().getOptional()) {
+                filtered.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return filtered;
+    }
+
+    // Return a new dependency which is the intersection of the two given dependencies. The rules
+    // for determining this are as follows:
+    // - The resulting plugin is optional iff both the given plugins are optional
+    // - the resulting plugin will have the higher of the given versions
+    // - any remaining plugin attributes will come from the plugin with the higher version
+    private Plugin combineDependencies(Plugin a, Plugin b) {
+        if (!a.getName().equals(b.getName())) {
+            throw new IllegalStateException("Can only combine dependencies on the same plugin. Got " + a.getName() + " and " + b.getName());
+        }
+
+        boolean resultIsOptional = a.getOptional() && b.getOptional();
+
+        Plugin higherVersion = a;
+        if (a.getVersion().isOlderThan(b.getVersion())) {
+            higherVersion = b;
+        }
+
+        higherVersion.setOptional(resultIsOptional);
+        return higherVersion;
     }
 
     private void calculateChecksum(Plugin requestedPlugin) {
@@ -808,22 +837,20 @@ public class PluginManager {
             }
             String[] dependencies = dependencyString.split(",");
 
-            //ignore optional dependencies
             for (String dependency : dependencies) {
-                if (!dependency.contains("resolution:=optional")) {
-                    String[] pluginInfo = dependency.split(":");
-                    String pluginName = pluginInfo[0];
-                    String pluginVersion = pluginInfo[1];
-                    Plugin dependentPlugin = new Plugin(pluginName, pluginVersion, null, null);
-                    if (useLatestSpecified && plugin.isLatest() || useLatestAll) {
-                        VersionNumber latestPluginVersion = getLatestPluginVersion(pluginName);
-                        dependentPlugin.setVersion(latestPluginVersion);
-                        dependentPlugin.setLatest(true);
-                    }
-
-                    dependentPlugins.add(dependentPlugin);
-                    dependentPlugin.setParent(plugin);
+                String[] pluginInfo = dependency.split(":");
+                String pluginName = pluginInfo[0];
+                String pluginVersion = pluginInfo[1];
+                Plugin dependentPlugin = new Plugin(pluginName, pluginVersion, null, null);
+                if (useLatestSpecified && plugin.isLatest() || useLatestAll) {
+                    VersionNumber latestPluginVersion = getLatestPluginVersion(pluginName);
+                    dependentPlugin.setVersion(latestPluginVersion);
+                    dependentPlugin.setLatest(true);
                 }
+                dependentPlugin.setOptional(dependency.contains("resolution:=optional"));
+
+                dependentPlugins.add(dependentPlugin);
+                dependentPlugin.setParent(plugin);
             }
             logVerbose(dependentPlugins.isEmpty() ? String.format("%n%s has no dependencies", plugin.getName()) :
                     String.format("%n%s depends on: %n", plugin.getName()) +
@@ -844,7 +871,7 @@ public class PluginManager {
 
     /**
      * Given a plugin and json that contains plugin information, determines the dependencies and returns the list of
-     * dependencies. Optional dependencies will be excluded.
+     * dependencies.
      *
      * @param plugin     for which to find dependencies
      * @param pluginJson json that will be parsed to find requested plugin's dependencies
@@ -860,19 +887,18 @@ public class PluginManager {
 
         for (int i = 0; i < dependencies.length(); i++) {
             JSONObject dependency = dependencies.getJSONObject(i);
-            boolean isPluginOptional = dependency.getBoolean("optional");
-            if (!isPluginOptional) {
-                String pluginName = dependency.getString("name");
-                String pluginVersion = dependency.getString("version");
-                Plugin dependentPlugin = new Plugin(pluginName, pluginVersion, null, null);
-                if (useLatestSpecified && plugin.isLatest() || useLatestAll) {
-                    VersionNumber latestPluginVersion = getLatestPluginVersion(pluginName);
-                    dependentPlugin.setVersion(latestPluginVersion);
-                    dependentPlugin.setLatest(true);
-                }
-                dependentPlugins.add(dependentPlugin);
-                dependentPlugin.setParent(plugin);
+            String pluginName = dependency.getString("name");
+            String pluginVersion = dependency.getString("version");
+            Plugin dependentPlugin = new Plugin(pluginName, pluginVersion, null, null);
+            if (useLatestSpecified && plugin.isLatest() || useLatestAll) {
+                VersionNumber latestPluginVersion = getLatestPluginVersion(pluginName);
+                dependentPlugin.setVersion(latestPluginVersion);
+                dependentPlugin.setLatest(true);
             }
+            dependentPlugin.setOptional(dependency.getBoolean("optional"));
+
+            dependentPlugins.add(dependentPlugin);
+            dependentPlugin.setParent(plugin);
         }
 
         logVerbose(dependentPlugins.isEmpty() ? String.format("%n%s has no dependencies", plugin.getName()) :
@@ -930,7 +956,7 @@ public class PluginManager {
 
     // TODO(oleg_nenashev): This method is private, because it is only a partial fix for https://github.com/jenkinsci/plugin-installation-manager-tool/issues/101
     // A full dependency graph resolution and removal of non-needed dependency trees is required
-    private Map<String, Plugin> resolveRecursiveDependencies(Plugin plugin, @CheckForNull Map<String, Plugin> topLevelDependencies) {
+    public Map<String, Plugin> resolveRecursiveDependencies(Plugin plugin, @CheckForNull Map<String, Plugin> topLevelDependencies) {
         Deque<Plugin> queue = new LinkedList<>();
         Map<String, Plugin> recursiveDependencies = new HashMap<>();
         queue.add(plugin);

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
@@ -962,7 +962,7 @@ public class PluginManagerTest {
 
         Plugin parent1 = new Plugin("parent1", "1.0", null, null);
         Plugin parent2 = new Plugin("replaced1", "1.0", null, null);
-        Plugin parent3= new Plugin("parent3", "1.2", null, null);
+        Plugin parent3 = new Plugin("parent3", "1.2", null, null);
 
         Plugin child1 = new Plugin("replaced1", "1.3", null, null);
         Plugin child2 = new Plugin("child2", "3.2.1", null, null);
@@ -992,10 +992,10 @@ public class PluginManagerTest {
         Map<String, Plugin> recursiveDependencies = pluginManagerSpy.resolveRecursiveDependencies(grandParent);
 
         assertThat(recursiveDependencies)
-                .hasSize(10)
                 .containsValues(
                         grandParent, parent1, child4, parent3, child2, child3,
-                        child8, child9, child5, child6);
+                        child8, child9, child5, child6)
+                .hasSize(10);
     }
 
 


### PR DESCRIPTION
The previous behavior around optional dependencies was incorrect in
some cases. If plugin A declares a required dependency on plugin C
at version N, and plugin B declares an optional dependency on plugin
C at version N+1, the resolver will completely ignore plugin B's
optional dependency and end up installing plugin C at version N. This
will break plugin B because plugin B is explicitly incompatible with
versions vefore its dependency.

To solve this, we keep optional plugins in the dependency graph until
the very end. If every dependency on a given plugin is optional, then
that plugin can be omitted from the resulting set. However, if any of
those plugins are non-optional, then that plugin must be included
in the result and the version of that plugin must be the highest
required version among all enumerated dependencies.