### PR TITLE
Optional plugins missing from update center should not fail installation

### DIFF
--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -926,7 +926,7 @@ public class PluginManager implements Closeable {
                 if (!dependentPlugin.getOptional()) {
                     throw e;
                 }
-                logWarning(String.format(
+                logVerbose(String.format(
                             "Unable to find optional plugin %s in update center %s. " +
                             "Ignoring until it becomes required.",
                             pluginName, jenkinsUcLatest));
@@ -1498,15 +1498,6 @@ public class PluginManager implements Closeable {
         if (verbose) {
             System.out.println(message);
         }
-    }
-
-    /**
-     * Outputs a message to standard error with a warning prefix.
-     *
-     * @param message informational string to output
-     */
-    public void logWarning(String message) {
-        System.err.println("WARN: " + message);
     }
 
     /**


### PR DESCRIPTION
When resolving plugin, we will eagerly check the update center
for plugin metadata, even when that plugin is optional. When the
plugin is missing from update center, we end up failing the
installation.

This does not make sense for optional plugins. These plugins are
likely never going to be installed, so it isn't a problem that
we are missing some metadata. Instead of failing the build, we
just print a warning.

If another plugin does depend on this missing plugin in a
non-optional way, we will fail the installation at that point.

Fixes #294