### PR TITLE
Parameterize hash function; continue to default to sha256

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ if the user doesn't have a home directory when it will go to: `$(pwd)/.cache/jen
 * `JENKINS_UC_DOWNLOAD`: used to configure the URL from where plugins will be downloaded from. Often used to cache or to proxy the Jenkins plugin download site. 
 If set then all plugins will be downloaded through that URL.
   
+* `JENKINS_UC_HASH_FUNCTION`: used to configure the hash function which checks content from UCs. Currently `SHA1` (deprecated), `SHA256` (default), and `SHA512` can be specified.
+
 #### Plugin Input Format
 The expected format for plugins in the .txt file or entered through the `--plugins` CLI option is `artifact ID:version` or `artifact ID:url` or `artifact:version:url`
 

--- a/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/CliOptions.java
+++ b/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/CliOptions.java
@@ -5,6 +5,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.util.VersionNumber;
 import io.jenkins.tools.pluginmanager.config.Config;
 import io.jenkins.tools.pluginmanager.config.Credentials;
+import io.jenkins.tools.pluginmanager.config.HashFunction;
 import io.jenkins.tools.pluginmanager.config.OutputFormat;
 import io.jenkins.tools.pluginmanager.config.PluginInputException;
 import io.jenkins.tools.pluginmanager.config.Settings;
@@ -172,6 +173,7 @@ class CliOptions {
                 .withUseLatestAll(isUseLatestAll())
                 .withSkipFailedPlugins(isSkipFailedPlugins())
                 .withCredentials(credentials)
+                .withHashFunction(getHashFunction())
                 .build();
     }
 
@@ -560,4 +562,22 @@ class CliOptions {
     public boolean isShowVersion() {
         return showVersion;
     }
+
+
+    /**
+     * Determines the hash function used with the Update Center
+     * set via environment variable only
+     *
+     * @return the string value for the hash function. Currently allows sha1, sha256(default), sha512
+     */
+    private HashFunction getHashFunction() {
+
+        String fromEnv = System.getenv("JENKINS_UC_HASH_FUNCTION");
+        if (StringUtils.isNotBlank(fromEnv)) {
+            return HashFunction.valueOf(fromEnv.toUpperCase());
+        } else {
+            return Settings.DEFAULT_HASH_FUNCTION;
+        }
+    }
+
 }

--- a/plugin-management-cli/src/test/java/io/jenkins/tools/pluginmanager/cli/CliOptionsTest.java
+++ b/plugin-management-cli/src/test/java/io/jenkins/tools/pluginmanager/cli/CliOptionsTest.java
@@ -73,6 +73,7 @@ public class CliOptionsTest {
             .and("JENKINS_UC_EXPERIMENTAL", "")
             .and("JENKINS_INCREMENTALS_REPO_MIRROR", "")
             .and("JENKINS_PLUGIN_INFO", "")
+            .and("JENKINS_UC_HASH_FUNCTION", "")
             .execute(options::setup);
 
         assertThat(cfg.getPluginDir()).hasToString(Settings.DEFAULT_PLUGIN_DIR_LOCATION);
@@ -83,6 +84,7 @@ public class CliOptionsTest {
         assertThat(cfg.getJenkinsUcExperimental()).hasToString(Settings.DEFAULT_EXPERIMENTAL_UPDATE_CENTER_LOCATION);
         assertThat(cfg.getJenkinsIncrementalsRepoMirror()).hasToString(Settings.DEFAULT_INCREMENTALS_REPO_MIRROR_LOCATION);
         assertThat(cfg.getJenkinsPluginInfo()).hasToString(Settings.DEFAULT_PLUGIN_INFO_LOCATION);
+        assertThat(cfg.getHashFunction()).isEqualTo(Settings.DEFAULT_HASH_FUNCTION);
     }
 
 

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Config.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Config.java
@@ -39,6 +39,7 @@ public class Config {
     private String jenkinsWar;
     private List<Plugin> plugins;
     private boolean verbose;
+    private HashFunction hashFunction;
     private URL jenkinsUc;
     private URL jenkinsUcExperimental;
     private URL jenkinsIncrementalsRepoMirror;
@@ -70,6 +71,7 @@ public class Config {
             boolean useLatestAll,
             boolean skipFailedPlugins,
             OutputFormat outputFormat,
+            HashFunction hashFunction,
             List<Credentials> credentials) {
         this.pluginDir = pluginDir;
         this.cleanPluginDir = cleanPluginDir;
@@ -91,6 +93,7 @@ public class Config {
         this.skipFailedPlugins = skipFailedPlugins;
         this.outputFormat = outputFormat;
         this.credentials = credentials;
+        this.hashFunction = hashFunction;
     }
 
     public File getPluginDir() {
@@ -178,6 +181,10 @@ public class Config {
         return new Builder();
     }
 
+    public HashFunction getHashFunction() {
+        return hashFunction;
+    }
+
     public static class Builder {
         private File pluginDir;
         private boolean cleanPluginDir;
@@ -199,6 +206,7 @@ public class Config {
         private boolean skipFailedPlugins;
         private OutputFormat outputFormat = OutputFormat.STDOUT;
         private List<Credentials> credentials = Collections.emptyList();
+        private HashFunction hashFunction = Settings.DEFAULT_HASH_FUNCTION;
 
         private Builder() {
         }
@@ -314,6 +322,11 @@ public class Config {
             return this;
         }
 
+        public Builder withHashFunction(HashFunction hashFunction) {
+            this.hashFunction = hashFunction;
+            return this;
+        }
+
         public Config build() {
             return new Config(
                     pluginDir,
@@ -335,6 +348,7 @@ public class Config {
                     useLatestAll,
                     skipFailedPlugins,
                     outputFormat,
+                    hashFunction,
                     credentials
             );
         }

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/HashFunction.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/HashFunction.java
@@ -1,0 +1,18 @@
+package io.jenkins.tools.pluginmanager.config;
+
+public enum HashFunction {
+    SHA1("sha1"),
+    SHA256("sha256"),
+    SHA512("sha512");
+
+    private String hashFunctionName;
+
+    HashFunction(String hashFunctionName) {
+        this.hashFunctionName = hashFunctionName;
+    }
+
+    @Override
+    public String toString(){
+        return hashFunctionName;
+    }
+}

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Settings.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Settings.java
@@ -18,6 +18,7 @@ public class Settings {
     public static final URL DEFAULT_PLUGIN_INFO;
     public static final String DEFAULT_PLUGIN_INFO_LOCATION = "https://updates.jenkins.io/plugin-versions.json";
     public static final Path DEFAULT_CACHE_PATH;
+    public static final HashFunction DEFAULT_HASH_FUNCTION = HashFunction.SHA256;
 
     static {
         String cacheBaseDir = System.getProperty("user.home");

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/Plugin.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/Plugin.java
@@ -22,7 +22,7 @@ public class Plugin {
     private boolean latest;
     private boolean experimental;
     private boolean optional;
-    private String sha256Checksum;
+    private String checksum;
     private VersionNumber jenkinsVersion;
 
     public Plugin(String name, String version, String url, String groupId) {
@@ -72,12 +72,12 @@ public class Plugin {
         this.latest = latest;
     }
 
-    public String getSha256Checksum() {
-        return sha256Checksum;
+    public String getChecksum() {
+        return checksum;
     }
 
-    public void setSha256Checksum(String sha256Checksum) {
-        this.sha256Checksum = sha256Checksum;
+    public void setChecksum(String checksum) {
+        this.checksum = checksum;
     }
 
     public String getName() {

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -1332,7 +1332,7 @@ public class PluginManager implements Closeable {
         }
     }
 
-    @SuppressFBWarnings(value = "WEAK_MESSAGE_DIGEST_SHA1", justification = "Needed for legacy purposes.")
+    @SuppressFBWarnings(value = "WEAK_MESSAGE_DIGEST_SHA1", justification = "CloudBees update center only uses sha1, remove sha1 once this has been updated.")
     private byte[] calculateChecksum(File pluginFile) {
         try (FileInputStream fin = new FileInputStream(pluginFile)) {
             HashFunction hashFunction = getHashFunction();

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/UnsupportedChecksumException.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/UnsupportedChecksumException.java
@@ -1,0 +1,12 @@
+package io.jenkins.tools.pluginmanager.impl;
+
+public class UnsupportedChecksumException extends RuntimeException {
+
+    public UnsupportedChecksumException(String message) {
+        super(message);
+    }
+
+    public UnsupportedChecksumException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/ChecksumTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/ChecksumTest.java
@@ -1,6 +1,7 @@
 package io.jenkins.tools.pluginmanager.impl;
 
 import io.jenkins.tools.pluginmanager.config.Config;
+import io.jenkins.tools.pluginmanager.config.HashFunction;
 import java.io.File;
 import java.net.URL;
 import org.junit.Before;
@@ -19,6 +20,7 @@ public class ChecksumTest {
         Config cfg = Config.builder()
                 .withJenkinsWar("")
                 .withIsVerbose(true)
+                .withHashFunction(HashFunction.SHA256)
                 .build();
 
         pm = new PluginManager(cfg);
@@ -27,7 +29,7 @@ public class ChecksumTest {
     @Test
     public void mailerPluginChecksumsMatch() {
         Plugin mailer = new Plugin("mailer", "1.32", null, null);
-        mailer.setSha256Checksum("BChiuBjHIiPxWZrBuVqB+QwxKWFknoim5jnCr4I55Lc=");
+        mailer.setChecksum("BChiuBjHIiPxWZrBuVqB+QwxKWFknoim5jnCr4I55Lc=");
 
         URL mailerHpi = this.getClass().getResource("mailer.hpi");
         File mailerFile = new File(mailerHpi.getFile());
@@ -38,7 +40,7 @@ public class ChecksumTest {
     @Test
     public void mailerPluginInvalidChecksums() {
         Plugin mailer = new Plugin("mailer", "1.32", null, null);
-        mailer.setSha256Checksum("jBChiuBjHIiPxWZrBuVqB+QwxKWFknoim5jnCr4I55Lc=");
+        mailer.setChecksum("jBChiuBjHIiPxWZrBuVqB+QwxKWFknoim5jnCr4I55Lc=");
 
         URL mailerHpi = this.getClass().getResource("mailer.hpi");
         File mailerFile = new File(mailerHpi.getFile());

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
@@ -370,7 +370,7 @@ public class PluginManagerTest {
         pm.setPluginInfoJson(pluginVersionJson);
 
         Plugin browserStackPlugin1 = new Plugin("browserstack-integration", "1.0.0", null, null);
-        browserStackPlugin1.setSha256Checksum("1234");
+        browserStackPlugin1.setChecksum("1234");
         JSONArray browserStackPluginJson1 = pm.getPluginDependencyJsonArray(browserStackPlugin1, pluginVersionJson);
         assertThat(browserStackPluginJson1)
                 .hasToString(dependencies1.toString());


### PR DESCRIPTION
Allows changing the hash function with an environment variable. I opted not to use a proper cli option, as this is probably obscure enough of a need that it doesn't warrant that. It does currently support sha1, as that is needed for certain legacy Update Centers (I raised a proper issue about this in #299). Will be easy enough to remove sha1 when time comes. This  effectively adds support for sha512, too.

Fixes #299.

Happy to discuss and update the PR as needed.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

