### PR TITLE
Fixes #316: When resolving dependencies using manifest, do not fail i…

### DIFF
--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -906,12 +906,19 @@ public class PluginManager implements Closeable {
                 String pluginName = pluginInfo[0];
                 String pluginVersion = pluginInfo[1];
                 Plugin dependentPlugin = new Plugin(pluginName, pluginVersion, null, null);
-                if (useLatestSpecified && plugin.isLatest() || useLatestAll) {
-                    VersionNumber latestPluginVersion = getLatestPluginVersion(plugin, pluginName);
-                    dependentPlugin.setVersion(latestPluginVersion);
-                    dependentPlugin.setLatest(true);
-                }
                 dependentPlugin.setOptional(dependency.contains("resolution:=optional"));
+
+                if (useLatestSpecified && plugin.isLatest() || useLatestAll) {
+                    try {
+                        VersionNumber latestPluginVersion = getLatestPluginVersion(plugin, pluginName);
+                        dependentPlugin.setVersion(latestPluginVersion);
+                        dependentPlugin.setLatest(true);
+                    } catch(PluginNotFoundException e) {
+                        if (! dependentPlugin.getOptional()) {
+                            throw e;
+                        }
+                    }
+                }
 
                 dependentPlugins.add(dependentPlugin);
                 dependentPlugin.setParent(plugin);


### PR DESCRIPTION
…f an optional plugin cannot be retrieved

Swallow the `PluginNotFoundException` if the dependency is optional.

Opening as a WIP PR, I'm not happy to have to do this this way but I'm not exactly sure how the optional dependencies are treated in the project, not sure why they are not skipped if they are causing trouble. Happy to discuss further to enhance the solution.
Once we agree on a solution I'll add tests.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
