### PR TITLE
Updated --output command description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ jenkins-plugin-cli --plugin-file /your/path/to/plugins.txt --plugins delivery-pi
 * `--view-security-warnings`: (optional) Set to true to show if any of the user specified plugins have security warnings
 * `--view-all-security-warnings`: (optional) Set to true to show all plugins that have security warnings.
 * `--available-updates`: (optional) Set to true to show if any requested plugins have newer versions available. If a Jenkins version-specific update center is available, the latest plugin version will be determined based on that update center's data.
-* `--output {json,stdout,yaml}`: (optional) Format to output plugin updates file in, stdout is the default.
+* `--output {stdout,yaml,txt}`: (optional) Format to output plugin updates file in, stdout is the default.
 * `--latest false`: (optional) Set to false to download the minimum required version of all dependencies.
 * `--latest-specified`: (optional) (advanced) Set to true to download latest dependencies of any plugin that is requested to have the latest version. All other plugin dependency versions are determined by the update center metadata or the plugin MANIFEST.MF.
 * `--jenkins-update-center`: (optional) Sets the main update center filename, which can also be set via the JENKINS_UC environment variable. If a CLI option is entered, it will override what is set in the environment variable. If not set via CLI option or environment variable, will default to https://updates.jenkins.io/update-center.actual.json


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Current versions of jenkins-plugin-cli support `--output` switch values: stdout, yaml, txt. (Reference: https://github.com/jenkinsci/plugin-installation-manager-tool/blob/28b405ff1ecc5f79bead0e5041b17cfce20bf887/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/OutputFormat.java#L3-L5 )

The command-line documentation is up-to-date as the values are autogenerated via reflection. However, the README contains stale information.

This change brings the README in line with the application itself, as far as the `--output` switch is concerned.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
