### PR TITLE
Correct version extraction from manifest with optional plugins

### DIFF
--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -923,7 +923,9 @@ public class PluginManager implements Closeable {
             String[] dependencies = dependencyString.split(",");
 
             for (String dependency : dependencies) {
-                String[] pluginInfo = dependency.split(":");
+                String[] pluginInfo = dependency
+                        .replace(";resolution:=optional", "")
+                        .split(":");
                 String pluginName = pluginInfo[0];
                 String pluginVersion = pluginInfo[1];
                 Plugin dependentPlugin = new Plugin(pluginName, pluginVersion, null, null);

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
@@ -791,11 +791,11 @@ public class PluginManagerTest {
                         new Plugin("credentials", "2.1.14", null, null),
                         new Plugin("git-client", "2.7.7", null, null),
                         new Plugin("mailer", "1.18", null, null),
-                        new Plugin("parameterized-trigger", "2.33;resolution", null, null).setOptional(true),
-                        new Plugin("promoted-builds", "2.27;resolution", null, null).setOptional(true),
+                        new Plugin("parameterized-trigger", "2.33", null, null).setOptional(true),
+                        new Plugin("promoted-builds", "2.27", null, null).setOptional(true),
                         new Plugin("scm-api", "2.6.3", null, null),
                         new Plugin("ssh-credentials", "1.13", null, null),
-                        new Plugin("token-macro", "1.12.1;resolution", null, null).setOptional(true));
+                        new Plugin("token-macro", "1.12.1", null, null).setOptional(true));
         assertThat(testPlugin.getVersion()).hasToString("1.0.0");
     }
 


### PR DESCRIPTION
Incrementals now resolve dependencies correctly when there is an optional plugin

Previously I was getting:

> Plugin azure-keyvault:125.vfe1a7baf2b0a depends on workflow-api:2.46;resolution, but there is an older version defined on the top level - workflow-api:2.46

This was because the version was set to '2.46;resolution', due to resolution=optional being on the line that was being split.

The tests had captured this mistake 😢 