### PR TITLE
Allow customising user agent with -Dhttp.agent

### DIFF
--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -134,18 +134,18 @@ public class PluginManager implements Closeable {
     }
 
     private String getUserAgentInformation() {
-        String userAgentInformation= "JenkinsPluginManager";
+        String addonUserAgent = System.getProperty("http.agent");
+        String userAgentInformation = addonUserAgent + " JenkinsPluginManager";
         Properties properties = new Properties();
         try (InputStream propertiesStream = this.getClass().getClassLoader().getResourceAsStream("version.properties")) {
                 properties.load(propertiesStream);
-                userAgentInformation = "JenkinsPluginManager" + "/" + properties.getProperty("project.version");
+                userAgentInformation = addonUserAgent + " JenkinsPluginManager" + "/" + properties.getProperty("project.version");
         }
         catch (IOException e) {
             logVerbose("Not able to load/detect version.properties file");
         }
         return userAgentInformation;
     }
-
     private HttpClient getHttpClient() {
         if (httpClient == null) {
             httpClient = HttpClients.custom().useSystemProperties()

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -139,8 +139,8 @@ public class PluginManager implements Closeable {
         String userAgentInformation = addonUserAgent + "JenkinsPluginManager";
         Properties properties = new Properties();
         try (InputStream propertiesStream = this.getClass().getClassLoader().getResourceAsStream("version.properties")) {
-                properties.load(propertiesStream);
-                userAgentInformation = addonUserAgent + "JenkinsPluginManager" + "/" + properties.getProperty("project.version");
+            properties.load(propertiesStream);
+            userAgentInformation = addonUserAgent + "JenkinsPluginManager" + "/" + properties.getProperty("project.version");
         }
         catch (IOException e) {
             logVerbose("Not able to load/detect version.properties file");

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -134,12 +134,13 @@ public class PluginManager implements Closeable {
     }
 
     private String getUserAgentInformation() {
-        String addonUserAgent = System.getProperty("http.agent");
-        String userAgentInformation = addonUserAgent + " JenkinsPluginManager";
+        // pull http.agent value and add space if http.agent is being provided, to then append to the default user agent header
+        String addonUserAgent = System.getProperty("http.agent").trim() + (System.getProperty("http.agent").trim().length() > 0 ? " " : "");
+        String userAgentInformation = addonUserAgent + "JenkinsPluginManager";
         Properties properties = new Properties();
         try (InputStream propertiesStream = this.getClass().getClassLoader().getResourceAsStream("version.properties")) {
                 properties.load(propertiesStream);
-                userAgentInformation = addonUserAgent + " JenkinsPluginManager" + "/" + properties.getProperty("project.version");
+                userAgentInformation = addonUserAgent + "JenkinsPluginManager" + "/" + properties.getProperty("project.version");
         }
         catch (IOException e) {
             logVerbose("Not able to load/detect version.properties file");

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -135,7 +135,7 @@ public class PluginManager implements Closeable {
 
     private String getUserAgentInformation() {
         // pull http.agent value and add space if http.agent is being provided, to then append to the default user agent header
-        String addonUserAgent = System.getProperty("http.agent").trim() + (System.getProperty("http.agent").trim().length() > 0 ? " " : "");
+        String addonUserAgent = (System.getProperty("http.agent") != null ? (System.getProperty("http.agent") + " "): "");
         String userAgentInformation = addonUserAgent + "JenkinsPluginManager";
         Properties properties = new Properties();
         try (InputStream propertiesStream = this.getClass().getClassLoader().getResourceAsStream("version.properties")) {

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -134,17 +134,20 @@ public class PluginManager implements Closeable {
     }
 
     private String getUserAgentInformation() {
-        // pull http.agent value and add space if http.agent is being provided, to then append to the default user agent header
-        String addonUserAgent = (System.getProperty("http.agent") != null ? (System.getProperty("http.agent") + " "): "");
-        String userAgentInformation = addonUserAgent + "JenkinsPluginManager";
+        String userAgentInformation = "JenkinsPluginManager";
         Properties properties = new Properties();
         try (InputStream propertiesStream = this.getClass().getClassLoader().getResourceAsStream("version.properties")) {
             properties.load(propertiesStream);
-            userAgentInformation = addonUserAgent + "JenkinsPluginManager" + "/" + properties.getProperty("project.version");
-        }
-        catch (IOException e) {
+            userAgentInformation =  "JenkinsPluginManager/" + properties.getProperty("project.version");
+        } catch (IOException e) {
             logVerbose("Not able to load/detect version.properties file");
         }
+
+        String additionalUserAgentInfo = System.getProperty("http.agent");
+        if (additionalUserAgentInfo != null) {
+            userAgentInformation = additionalUserAgentInfo + " " + userAgentInformation;
+        }
+
         return userAgentInformation;
     }
     private HttpClient getHttpClient() {


### PR DESCRIPTION
Proposed fix for this issue:
https://github.com/jenkinsci/plugin-installation-manager-tool/issues/363

Append the value of System.getProperty("http.agent") to the userAgentInformation variable used to populate the user agent header.

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
