### PR TITLE
Add support for file:// protocol in plugin URI

### DIFF
--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -1282,7 +1282,7 @@ public class PluginManager implements Closeable {
 
     /**
      * Downloads a plugin from HTTP(s) location
-     * 
+     *
      * @param pluginUrl     location to download plugin to.
      * @param plugin        to download
      * @param pluginFile    location to store the plugin file.

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -21,7 +21,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.CopyOption;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -1244,7 +1243,7 @@ public class PluginManager implements Closeable {
         }
 
         boolean success = true;
-        
+
         if(urlString.startsWith("http://") || urlString.startsWith("https://")){
             success = downloadHttpToFile(urlString, plugin, pluginFile, maxRetries);
 
@@ -1283,14 +1282,14 @@ public class PluginManager implements Closeable {
 
     /**
      * Downloads a plugin from HTTP(s) location
-     *
-     * @param pluginUrl     location to download plugin to. 
+     * 
+     * @param pluginUrl     location to download plugin to.
      * @param plugin        to download
      * @param pluginFile    location to store the plugin file.
      *                      If file already exists, it will be overrided.
      * @param maxRetries   Maximum number of times to retry the download before failing
      * @return              boolean signifying if plugin was successfully downloaded
-     * 
+     *
      */
     protected boolean downloadHttpToFile(String pluginUrl, Plugin plugin, File pluginFile, int maxRetries){
         boolean success = false;
@@ -1357,7 +1356,7 @@ public class PluginManager implements Closeable {
       /**
      * Downloads a plugin from local folder location
      *
-     * @param pluginUrl location to download plugin to.  
+     * @param pluginUrl location to download plugin to.
      * @param plugin   to download
      * @param pluginFile    location to store the plugin file.
      *                      If file already exists, it will be overrided.
@@ -1382,10 +1381,7 @@ public class PluginManager implements Closeable {
             System.out.println(message);
             success = false;
         }
-
         return success;
-
-        
     }
 
     private CredentialsProvider getCredentialsProvider() {

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -1289,7 +1289,6 @@ public class PluginManager implements Closeable {
      *                      If file already exists, it will be overrided.
      * @param maxRetries   Maximum number of times to retry the download before failing
      * @return              boolean signifying if plugin was successfully downloaded
-     *
      */
     protected boolean downloadHttpToFile(String pluginUrl, Plugin plugin, File pluginFile, int maxRetries){
         boolean success = false;

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -21,9 +21,11 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.CopyOption;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
@@ -1123,11 +1125,12 @@ public class PluginManager implements Closeable {
 
     /**
      * Downloads a plugin, skipping if already installed or bundled in the war. A plugin's dependencies will be
-     * resolved after the plugin is downloaded.
+     * resolved after the plugin is downloaded/copied.
      *
      * @param plugin   to download
      * @param location location to download plugin to. If location is set to {@code null}, will download to the plugin folder
      *                 otherwise will download to the temporary location specified.
+     *                 Location can be in form of a http://, https:// or file:// URI
      * @return boolean signifying if plugin was successful
      */
     public boolean downloadPlugin(Plugin plugin, @CheckForNull File location) {
@@ -1241,6 +1244,56 @@ public class PluginManager implements Closeable {
         }
 
         boolean success = true;
+        
+        if(urlString.startsWith("http://") || urlString.startsWith("https://")){
+            success = downloadHttpToFile(urlString, plugin, pluginFile, maxRetries);
+
+            if (!success && !urlString.startsWith(MIRROR_FALLBACK_BASE_URL)) {
+                System.out.println("Downloading from mirrors failed, falling back to " + MIRROR_FALLBACK_BASE_URL);
+                // as fallback try to directly download from Jenkins server (only if mirrors fail)
+                urlString = appendPathOntoUrl(MIRROR_FALLBACK_BASE_URL, "/plugins", plugin.getName(), plugin.getVersion(), plugin.getName() + ".hpi");
+                return downloadToFile(urlString, plugin, fileLocation, 1);
+            }
+        } else if (urlString.startsWith("file://")){
+            success = copyLocalFile(urlString, plugin, pluginFile);
+        }
+
+        
+
+        if (success) {
+            // Check integrity of plugin file
+            try (JarFile ignored = new JarFile(pluginFile)) {
+                verifyChecksum(plugin, pluginFile);
+                plugin.setFile(pluginFile);
+            } catch (IOException e) {
+                failedPlugins.add(plugin);
+                System.out.println("Downloaded file is not a valid ZIP");
+                if (verbose) {
+                    e.printStackTrace();
+                }
+                return false;
+            } catch (PluginChecksumMismatchException e) {
+                failedPlugins.add(plugin);
+                System.out.println(e.getMessage());
+                return false;
+            }
+        } else {
+            failedPlugins.add(plugin);
+        }
+        return success;
+    }
+
+    /**
+     * Downloads a plugin from HTTP(s) location
+     *
+     * @param urlString     location to download plugin to. 
+     * @param plugin        to download
+     * @param pluginFile    location to store the plugin file.
+     *                      If file already exists, it will be overrided.
+     * @return              boolean signifying if plugin was successfully downloaded
+     */
+    protected boolean downloadHttpToFile(String urlString, Plugin plugin, File pluginFile, int maxRetries){
+        boolean success = false;
         for (int i = 0; i < maxRetries; i++) {
             success = true;
             try {
@@ -1298,35 +1351,41 @@ public class PluginManager implements Closeable {
                 }
             }
         }
-
-        if (!success && !urlString.startsWith(MIRROR_FALLBACK_BASE_URL)) {
-            System.out.println("Downloading from mirrors failed, falling back to " + MIRROR_FALLBACK_BASE_URL);
-            // as fallback try to directly download from Jenkins server (only if mirrors fail)
-            urlString = appendPathOntoUrl(MIRROR_FALLBACK_BASE_URL, "/plugins", plugin.getName(), plugin.getVersion(), plugin.getName() + ".hpi");
-            return downloadToFile(urlString, plugin, fileLocation, 1);
-        }
-
-        if (success) {
-            // Check integrity of plugin file
-            try (JarFile ignored = new JarFile(pluginFile)) {
-                verifyChecksum(plugin, pluginFile);
-                plugin.setFile(pluginFile);
-            } catch (IOException e) {
-                failedPlugins.add(plugin);
-                System.out.println("Downloaded file is not a valid ZIP");
-                if (verbose) {
-                    e.printStackTrace();
-                }
-                return false;
-            } catch (PluginChecksumMismatchException e) {
-                failedPlugins.add(plugin);
-                System.out.println(e.getMessage());
-                return false;
-            }
-        } else {
-            failedPlugins.add(plugin);
-        }
         return success;
+    }
+
+      /**
+     * Downloads a plugin from local folder location
+     *
+     * @param plugin   to download
+     * @param location location to download plugin to. 
+     * @param pluginFile    location to store the plugin file.
+     *                      If file already exists, it will be overrided.
+     * @return boolean signifying if plugin was successfully downloaded
+     */
+    protected boolean copyLocalFile(String urlString, Plugin plugin, File pluginFile){
+        boolean success = false;
+        try {
+            File originFile = new File(new URI(urlString));
+            if(originFile.exists()){
+                Files.copy(originFile.toPath(), pluginFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                success = true;
+            } else {
+                String message = String.format("Unable to copy plugin URL %s, original file does not exists or is not accessible", originFile.getAbsolutePath());
+                System.out.println(message);
+            }
+        } catch (URISyntaxException | InvalidPathException | IOException e) {
+            System.out.println("ERROR " + e.getClass().toGenericString() );
+
+            String message = String.format("Unable to resolve plugin URL %s, or copy plugin %s to file: %s",
+            urlString, plugin.getName(), e.getMessage());
+            System.out.println(message);
+            success = false;
+        }
+
+        return success;
+
+        
     }
 
     private CredentialsProvider getCredentialsProvider() {

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
@@ -41,6 +41,8 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
 
 public class PluginManagerTest {
     private PluginManager pm;
@@ -1183,6 +1185,18 @@ public class PluginManagerTest {
                         new Plugin("github-branch-source", "1.8", null, null));
     }
 
+
+    @Test
+    public void getPluginFromLocalFolderTest() {
+        PluginManager pluginManagerSpy = spy(pm);
+        Plugin testPlugin = new Plugin("test", "latest", "file:///tmp/test.jar", null);
+
+        pluginManagerSpy.downloadToFile(testPlugin.getUrl(), testPlugin, new File("/tmp/test.jar"));
+
+        verify(pluginManagerSpy, times(1)).copyLocalFile(any(String.class), any(Plugin.class), any(File.class));
+
+    }
+
     private JSONObject setTestUcJson() {
         JSONObject latestUcJson = new JSONObject();
 
@@ -1316,6 +1330,8 @@ public class PluginManagerTest {
         pm.setExperimentalUcJson(latestUcJson);
         return latestUcJson;
     }
+
+
 
     private JSONArray array(
             JSONObject... objects) {


### PR DESCRIPTION
Allow to install plugin from local folder with the file:// format, linked to #365 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Refactored the PluginManager.downloadToFile function to add condition on the URL format to manage HTTPs/HTTP and file protocol.
Extract the current http fetch into a dedicated internal function.
