### PR TITLE
Adjust download url precedence

### DIFF
--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -1175,10 +1175,6 @@ public class PluginManager implements Closeable {
         String jenkinsUcDownloadUrl = System.getenv("JENKINS_UC_DOWNLOAD_URL");
         if (StringUtils.isNotEmpty(pluginUrl)) {
             urlString = pluginUrl;
-        } else if (StringUtils.isNotEmpty(jenkinsUcDownloadUrl)) {
-            urlString = appendPathOntoUrl(jenkinsUcDownloadUrl, pluginName, pluginVersion, pluginName + ".hpi");
-        } else if (StringUtils.isNotEmpty(jenkinsUcDownload)) {
-            urlString = appendPathOntoUrl(jenkinsUcDownload, "/plugins", pluginName, pluginVersion, pluginName + ".hpi");
         } else if ((pluginVersion.equals("latest") || plugin.isLatest()) && !StringUtils.isEmpty(jenkinsUcLatest)) {
             JSONObject plugins = latestUcJson.getJSONObject("plugins");
             if (plugins.has(plugin.getName())) {
@@ -1200,6 +1196,10 @@ public class PluginManager implements Closeable {
             groupId = groupId.replace(".", "/");
             String incrementalsVersionPath = String.format("%s/%s/%s-%s.hpi", pluginName, pluginVersion, pluginName, pluginVersion);
             urlString = appendPathOntoUrl(cfg.getJenkinsIncrementalsRepoMirror(), groupId, incrementalsVersionPath);
+        } else if (StringUtils.isNotEmpty(jenkinsUcDownloadUrl)) {
+            urlString = appendPathOntoUrl(jenkinsUcDownloadUrl, pluginName, pluginVersion, pluginName + ".hpi");
+        } else if (StringUtils.isNotEmpty(jenkinsUcDownload)) {
+            urlString = appendPathOntoUrl(jenkinsUcDownload, "/plugins", pluginName, pluginVersion, pluginName + ".hpi");
         } else {
             urlString = appendPathOntoUrl(removePath(cfg.getJenkinsUc()), "/download/plugins", pluginName, pluginVersion, pluginName + ".hpi");
         }


### PR DESCRIPTION
Reorder plugin download url logic to align with existing docker install-plugins.sh script.

https://github.com/jenkinsci/docker/blob/master/install-plugins.sh#L84-L106

When configuring custom update center proxy, as one might do with Artifactory in corporate environment, all
the update center urls including the JENKINS_UC_DOWNLOAD_URL need to be overridden. With the previous 
ordering the download url would take precedence resulting in an invalid url when installing a plugin with version 
"latest".

For example given the follow setup

```shell
export JENKINS_UC=https://private-mirror.com/jenkins-updated-center/dynamic-stable-2.319.1/update-center-actual.json?version=2.319.1
export JENKINS_UC_DOWNLOAD_URL=https://private-mirror.com/jenkins-updated-center/download/plugins
export JENKINS_UC_EXPERIMENTAL=https://private-mirror.com/jenkins-updated-center/experimental/update-center.actual.json
export JENKINS_INCREMENTALS_REPO_MIRROR=https://private-mirror.com/jenkins-updated-center/incrementals
export JENKINS_PLUGIN_INFO=https://private-mirror.com/jenkins-updated-center/current/plugin-versions.json

java -jar jenkins-plugin-manager-*.jar --plugins docker
```

The previous logic would result in the download url:

```
https://private-mirror.com/jenkins-updated-center/download/plugins/latest/docker.hpi
```

with this change set the url will be:

```
https://private-mirror.com/jenkins-updated-center/dynamic-stable-2.319.1/latest/docker.hpi
```

- [x ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ x] Ensure that the pull request title represents the desired changelog entry
- [x ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
