### PR TITLE
Fix latest and experimental URL resolution

### DIFF
--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/Plugin.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/Plugin.java
@@ -9,6 +9,8 @@ import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 
 public class Plugin {
+    public static final String LATEST = "latest";
+    public static final String EXPERIMENTAL = "experimental";
     private String name;
     private VersionNumber version;
     private String groupId;
@@ -28,7 +30,7 @@ public class Plugin {
     public Plugin(String name, String version, String url, String groupId) {
         this.name = name;
         if (StringUtils.isEmpty(version)) {
-            version = "latest";
+            version = Plugin.LATEST;
         }
         this.version = new VersionNumber(version);
         this.url = url;
@@ -36,10 +38,10 @@ public class Plugin {
         this.parent = this;
         this.groupId = groupId;
         this.securityWarnings = new ArrayList<>();
-        if (version.equals("latest")) {
+        if (version.equals(Plugin.LATEST)) {
             latest = true;
         }
-        if (version.equals("experimental")) {
+        if (version.equals(Plugin.EXPERIMENTAL)) {
             experimental = true;
         }
     }

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
@@ -1175,7 +1175,7 @@ public class PluginManagerTest {
         assertThat(pluginManager.getPluginDownloadUrl(plugin))
                 .isEqualTo("https://private-mirror.com/jenkins-updated-center/dynamic-stable-2.319.1/latest/pluginName.hpi");
 
-        // lastest version with resolved version
+        // latest version with resolved version
         // when `--latest-specified` or `--latest` is enabled the plugin version string will be updated to a specific
         // version and the latest flag set to true. The resolved download url should resolve to JENKINS_UC_DOWNLOAD_URL
         plugin = new Plugin("pluginName", "1.0.0", null, null);


### PR DESCRIPTION
When `--latest-specified` or `--latest` is enabled plugins will be resolved to the
latest plugin version but also be marked as `latest = true`. When this happens
the download url should use the configured download url
(i.e. `JENKINS_UC_DOWNLOAD_URL`) or jenkins update center
(i.e. `JENKINS_UC`).

Similar for plugins that specify the "experimental" version should use the
jenkins experimental update center (i.e. `JENKINS_UC_EXPERIMENTAL `).
Unlike "latest" these don't appear to be resolved to specific versions prior
to resolving the download url.

Fixes #287 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
