### PR TITLE
Revert "Bump wiremock-jre8 from 2.32.0 to 2.33.0"

### DIFF
--- a/plugin-management-library/pom.xml
+++ b/plugin-management-library/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
           <groupId>com.github.tomakehurst</groupId>
           <artifactId>wiremock-jre8</artifactId>
-          <version>2.33.0</version>
+          <version>2.32.0</version>
           <scope>test</scope>
           <exclusions>
             <exclusion>


### PR DESCRIPTION
Reverts jenkinsci/plugin-installation-manager-tool#429