### PR TITLE
Support output format for list option

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,3 +189,35 @@ Support for downloading plugins from maven is not currently supported. [JENKINS-
 When using `--latest` you may run into a scenario where the jenkins update mirror contains the directory of the newer version of a plugin(release in progress), regardless of if there is a jpi to download, which results in a download failure. It's recommended that you pin your plugin requirement versions until the mirror has been updated to more accurately represent what is available. More information on this challenge can be found [here](https://groups.google.com/forum/#!topic/jenkins-infra/R7QqpgoSkbI), and [here](https://github.com/jenkinsci/plugin-installation-manager-tool/issues/87).
 
 The version-pinning behavior of this plugin installer has changed compared to the previous Jenkins plugin installer. By default, `--latest` option defaults to `true`, which means that even if you pass a list of pinned versions, these may fail to be installed correctly if they or some other dependency has a newer latest version available. In order to use *only* pinned versions of plugins, you must pass `--latest=false`. **NOTE:** When a new dependency is added to a plugin, it won’t get updated until you notice that it’s missing from your plugin list. (Details here: https://github.com/jenkinsci/plugin-installation-manager-tool/issues/250)
+
+### Development
+
+Information on developing and contributing to this project.
+
+#### System Output
+
+**Send output to stdout**. The primary output for your command should go to stdout. Anything that is machine readable 
+should also go to stdout—this is where piping sends things by default.
+
+**Send messaging to stderr**. Log messages, errors, and so on should all be sent to stderr. This means that when commands 
+are piped together, these messages are displayed to the user and not fed into the next command.
+
+For more information on basic cli best practices see [clig.dev](https://clig.dev/)
+
+#### Building and Testing
+
+Use maven to build and test locally.
+```shell
+mvn clean install
+```
+
+To test changes in a Jenkins Docker image run the following changes.
+```shell
+# build the plugin to generate cli jar in plugin-management-cli/target
+mvn clean install
+# build jenkins image with updated cli jar
+docker build -t jnks-plugin-tool -f plugin-management-cli/src/test/docker/Dockerfile plugin-management-cli/
+# run the image
+docker run --rm -it --entrypoint bash jnks-plugin-tool
+jenkins@9aa5a8051b4d:~$ jenkins-plugin-cli --help
+```

--- a/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/CliOptions.java
+++ b/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/CliOptions.java
@@ -74,7 +74,7 @@ class CliOptions {
     private boolean showAvailableUpdates;
 
     @Option(name = "--output", usage = "Output format for available updates",   aliases = "-o")
-    private OutputFormat outputFormat;
+    private OutputFormat outputFormat = OutputFormat.STDOUT;
 
     @Option(name = "--view-security-warnings",
             usage = "Show if any security warnings exist for the requested plugins",
@@ -177,6 +177,7 @@ class CliOptions {
                 .build();
     }
 
+    @NonNull
     public OutputFormat getOutputFormat() {
         return outputFormat;
     }
@@ -189,14 +190,10 @@ class CliOptions {
      */
     private File getPluginFile() {
         if (pluginFile == null) {
-            if (verbose) {
-                System.out.println("No .txt or .yaml file containing list of plugins to be downloaded entered.");
-            }
+            logVerbose("No .txt or .yaml file containing list of plugins to be downloaded entered.");
         } else {
             if (Files.exists(pluginFile.toPath())) {
-                if (verbose) {
-                    System.out.println("File containing list of plugins to be downloaded: " + pluginFile);
-                }
+                logVerbose("File containing list of plugins to be downloaded: " + pluginFile);
             } else {
                 throw new PluginInputException("File containing list of plugins does not exist " + pluginFile.toPath());
             }
@@ -210,21 +207,14 @@ class CliOptions {
     @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "we want the user to be able to specify a path")
     private File getPluginDir() {
         if (pluginDir != null) {
-            if (verbose) {
-                System.out.println("Plugin download location: " + pluginDir);
-            }
+            logVerbose("Plugin download location: " + pluginDir);
             return pluginDir;
         } else if (!StringUtils.isEmpty(System.getenv("PLUGIN_DIR"))) {
-            if (verbose) {
-                System.out.println("No directory to download plugins entered. " +
-                        "Will use location specified in PLUGIN_DIR environment variable: " + System.getenv("PLUGIN_DIR"));
-            }
+            logVerbose("No directory to download plugins entered. " +
+                    "Will use location specified in PLUGIN_DIR environment variable: " + System.getenv("PLUGIN_DIR"));
             return new File(System.getenv("PLUGIN_DIR"));
         }
-        if (verbose) {
-            System.out.println("No directory to download plugins entered. " +
-                    "Will use default of " + Settings.DEFAULT_PLUGIN_DIR_LOCATION);
-        }
+        logVerbose("No directory to download plugins entered. Will use default of " + Settings.DEFAULT_PLUGIN_DIR_LOCATION);
         return new File(Settings.DEFAULT_PLUGIN_DIR_LOCATION);
     }
 
@@ -255,14 +245,10 @@ class CliOptions {
      */
     private String getJenkinsWar() {
         if (jenkinsWarFile == null) {
-            if (verbose) {
-                System.out.println("No war entered. Will use default of " + Settings.DEFAULT_WAR);
-            }
+            logVerbose("No war entered. Will use default of " + Settings.DEFAULT_WAR);
             return Settings.DEFAULT_WAR;
         } else {
-            if (verbose) {
-                System.out.println("Will use war file: " + jenkinsWarFile);
-            }
+            logVerbose("Will use war file: " + jenkinsWarFile);
             return jenkinsWarFile;
         }
     }
@@ -350,22 +336,15 @@ class CliOptions {
         try {
             if (jenkinsUc != null) {
                 jenkinsUpdateCenter = new URL(appendFilePathIfNotPresent(jenkinsUc.toString()));
-                if (verbose) {
-                    System.out.println("Using update center " + jenkinsUpdateCenter + " specified with CLI option");
-                }
+                logVerbose("Using update center " + jenkinsUpdateCenter + " specified with CLI option");
             } else {
                 String jenkinsUcFromEnv = System.getenv("JENKINS_UC");
                 if (!StringUtils.isEmpty(jenkinsUcFromEnv)) {
                     jenkinsUpdateCenter = new URL(appendFilePathIfNotPresent(jenkinsUcFromEnv));
-                    if (verbose) {
-                        System.out.println("Using update center " + jenkinsUpdateCenter + " from JENKINS_UC environment variable");
-                    }
+                    logVerbose("Using update center " + jenkinsUpdateCenter + " from JENKINS_UC environment variable");
                 } else {
                     jenkinsUpdateCenter = Settings.DEFAULT_UPDATE_CENTER;
-                    if (verbose) {
-                        System.out.println("No CLI option or environment variable set for update center, using default of " +
-                                jenkinsUpdateCenter);
-                    }
+                    logVerbose("No CLI option or environment variable set for update center, using default of " + jenkinsUpdateCenter);
                 }
             }
         } catch (MalformedURLException e) {
@@ -397,23 +376,14 @@ class CliOptions {
         try {
             if (jenkinsUcExperimental != null) {
                 experimentalUpdateCenter = new URL(appendFilePathIfNotPresent(jenkinsUcExperimental.toString()));
-                if (verbose) {
-                    System.out.println(
-                            "Using experimental update center " + experimentalUpdateCenter + " specified with CLI option");
-                }
+                logVerbose("Using experimental update center " + experimentalUpdateCenter + " specified with CLI option");
             } else if (!StringUtils.isEmpty(System.getenv("JENKINS_UC_EXPERIMENTAL"))) {
                 experimentalUpdateCenter = new URL(appendFilePathIfNotPresent(System.getenv("JENKINS_UC_EXPERIMENTAL")));
-                if (verbose) {
-                    System.out.println("Using experimental update center " + experimentalUpdateCenter +
-                            " from JENKINS_UC_EXPERIMENTAL environment variable");
-                }
+                logVerbose("Using experimental update center " + experimentalUpdateCenter + " from JENKINS_UC_EXPERIMENTAL environment variable");
             } else {
                 experimentalUpdateCenter = Settings.DEFAULT_EXPERIMENTAL_UPDATE_CENTER;
-                if (verbose) {
-                    System.out.println(
-                            "No CLI option or environment variable set for experimental update center, using default of " +
-                                    experimentalUpdateCenter);
-                }
+                logVerbose("No CLI option or environment variable set for experimental update center, using default of " +
+                        experimentalUpdateCenter);
             }
         } catch (MalformedURLException e) {
             /* Spotbugs 4.7.0 warns when throwing a runtime exception,
@@ -436,9 +406,7 @@ class CliOptions {
         URL jenkinsIncrementalsRepo;
         if (jenkinsIncrementalsRepoMirror != null) {
             jenkinsIncrementalsRepo = jenkinsIncrementalsRepoMirror;
-            if (verbose) {
-                System.out.println("Using incrementals mirror " + jenkinsIncrementalsRepo + " specified with CLI option");
-            }
+            logVerbose("Using incrementals mirror " + jenkinsIncrementalsRepo + " specified with CLI option");
         } else if (!StringUtils.isEmpty(System.getenv("JENKINS_INCREMENTALS_REPO_MIRROR"))) {
             try {
                 jenkinsIncrementalsRepo = new URL(System.getenv("JENKINS_INCREMENTALS_REPO_MIRROR"));
@@ -449,16 +417,13 @@ class CliOptions {
              */
                 throw new RuntimeException(e);
             }
-            if (verbose) {
-                System.out.println("Using incrementals mirror " + jenkinsIncrementalsRepo +
-                        " from JENKINS_INCREMENTALS_REPO_MIRROR environment variable");
-            }
+
+            logVerbose("Using incrementals mirror " + jenkinsIncrementalsRepo +
+                    " from JENKINS_INCREMENTALS_REPO_MIRROR environment variable");
         } else {
             jenkinsIncrementalsRepo = Settings.DEFAULT_INCREMENTALS_REPO_MIRROR;
-            if (verbose) {
-                System.out.println("No CLI option or environment variable set for incrementals mirror, using default of " +
-                        jenkinsIncrementalsRepo);
-            }
+            logVerbose("No CLI option or environment variable set for incrementals mirror, using default of " +
+                    jenkinsIncrementalsRepo);
         }
         return jenkinsIncrementalsRepo;
     }
@@ -474,9 +439,7 @@ class CliOptions {
         URL pluginInfo;
         if (jenkinsPluginInfo != null) {
             pluginInfo = jenkinsPluginInfo;
-            if (verbose) {
-                System.out.println("Using plugin info " + jenkinsPluginInfo + " specified with CLI option");
-            }
+            logVerbose("Using plugin info " + jenkinsPluginInfo + " specified with CLI option");
         } else if (!StringUtils.isEmpty(System.getenv("JENKINS_PLUGIN_INFO"))) {
             try {
                 pluginInfo = new URL(System.getenv("JENKINS_PLUGIN_INFO"));
@@ -487,16 +450,11 @@ class CliOptions {
                  */
                 throw new RuntimeException(e);
             }
-            if (verbose) {
-                System.out.println("Using plugin info " + pluginInfo +
-                        " from JENKINS_PLUGIN_INFO environment variable");
-            }
+
+            logVerbose("Using plugin info " + pluginInfo + " from JENKINS_PLUGIN_INFO environment variable");
         } else {
             pluginInfo = Settings.DEFAULT_PLUGIN_INFO;
-            if (verbose) {
-                System.out.println("No CLI option or environment variable set for plugin info, using default of " +
-                        pluginInfo);
-            }
+            logVerbose("No CLI option or environment variable set for plugin info, using default of " + pluginInfo);
         }
         return pluginInfo;
     }
@@ -597,6 +555,18 @@ class CliOptions {
             return HashFunction.valueOf(fromEnv.toUpperCase());
         } else {
             return Settings.DEFAULT_HASH_FUNCTION;
+        }
+    }
+
+    /**
+     * Outputs information to the console (std err) if verbose option was set to true
+     *
+     * @param message informational string to output
+     */
+    private void logVerbose(String message) {
+        if (verbose) {
+            // log to stderr to not interfere with primary cli output sent to stdout
+            System.err.println(message);
         }
     }
 

--- a/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/Main.java
+++ b/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/Main.java
@@ -2,12 +2,9 @@ package io.jenkins.tools.pluginmanager.cli;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.jenkins.tools.pluginmanager.config.Config;
-import io.jenkins.tools.pluginmanager.config.OutputFormat;
 import io.jenkins.tools.pluginmanager.impl.Plugin;
 import io.jenkins.tools.pluginmanager.impl.PluginManager;
-import io.jenkins.tools.pluginmanager.parsers.StdOutPluginOutputConverter;
-import io.jenkins.tools.pluginmanager.parsers.TxtOutputConverter;
-import io.jenkins.tools.pluginmanager.parsers.YamlPluginOutputConverter;
+import io.jenkins.tools.pluginmanager.parsers.AvailableUpdatesStdOutPluginOutputConverter;
 import java.io.IOException;
 import java.util.List;
 import org.kohsuke.args4j.CmdLineException;
@@ -47,27 +44,13 @@ public class Main {
 
             Config cfg = options.setup();
             try (PluginManager pm = new PluginManager(cfg)) {
-
                 if (options.isShowAvailableUpdates()) {
                     pm.getUCJson(pm.getJenkinsVersion());
                     List<Plugin> latestVersionsOfPlugins = pm.getLatestVersionsOfPlugins(cfg.getPlugins());
-                    OutputFormat outputFormat = options.getOutputFormat() == null ? OutputFormat.STDOUT : options.getOutputFormat();
-                    String output;
-                    switch (outputFormat) {
-                        case YAML:
-                            output = new YamlPluginOutputConverter().convert(latestVersionsOfPlugins);
-                            break;
-                        case TXT:
-                            output = new TxtOutputConverter().convert(latestVersionsOfPlugins);
-                            break;
-                        default:
-                            output = new StdOutPluginOutputConverter(cfg.getPlugins()).convert(latestVersionsOfPlugins);
-                    }
-                    System.out.println(output);
-                    return;
+                    pm.outputPluginList(latestVersionsOfPlugins, () -> new AvailableUpdatesStdOutPluginOutputConverter(cfg.getPlugins()));
+                } else {
+                    pm.start();
                 }
-
-                pm.start();
             }
         } catch (Exception e) {
             if (options.isVerbose()) {

--- a/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/VersionNumberHandler.java
+++ b/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/VersionNumberHandler.java
@@ -20,7 +20,7 @@ public class VersionNumberHandler extends OneArgumentOptionHandler<VersionNumber
         try {
             return new VersionNumber(argument);
         } catch (Exception ex) {
-            throw new CmdLineException("Failed to parse the version number", ex);
+            throw new CmdLineException(owner, "Failed to parse the version number", ex);
         }
     }
 

--- a/plugin-management-cli/src/test/docker/Dockerfile
+++ b/plugin-management-cli/src/test/docker/Dockerfile
@@ -1,0 +1,11 @@
+# From 'plugin-management-cli' dir:
+# build:
+#   docker build -t jnks-plugin-tool -f src/test/docker/Dockerfile .
+# run:
+#   docker run --rm -it jnks-plugin-tool
+#   docker run --rm -it --entrypoint bash jnks-plugin-tool
+#
+FROM jenkins/jenkins:lts
+COPY target/jenkins-plugin-manager-*.jar /opt/jenkins-plugin-manager.jar
+WORKDIR $JENKINS_HOME
+ENTRYPOINT ["java", "-jar", "/opt/jenkins-plugin-manager.jar"]

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Config.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Config.java
@@ -1,10 +1,12 @@
 package io.jenkins.tools.pluginmanager.config;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.util.VersionNumber;
 import io.jenkins.tools.pluginmanager.impl.Plugin;
 import java.io.File;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -20,36 +22,39 @@ import java.util.List;
  * Defaults for update centers will be set for you
  */
 public class Config {
-    private File pluginDir;
-    private boolean cleanPluginDir;
-    private boolean showWarnings;
-    private boolean showAllWarnings;
-    private boolean showAvailableUpdates;
-    private boolean showPluginsToBeDownloaded;
+    private final File pluginDir;
+    private final boolean cleanPluginDir;
+    private final boolean showWarnings;
+    private final boolean showAllWarnings;
+    private final boolean showAvailableUpdates;
+    private final boolean showPluginsToBeDownloaded;
 
     /**
      * Explicitly passed Jenkins version.
      */
     @CheckForNull
-    private VersionNumber jenkinsVersion;
+    private final VersionNumber jenkinsVersion;
     /**
      * Path to the Jenkins WAR file.
      */
     @CheckForNull
-    private String jenkinsWar;
-    private List<Plugin> plugins;
-    private boolean verbose;
-    private HashFunction hashFunction;
-    private URL jenkinsUc;
-    private URL jenkinsUcExperimental;
-    private URL jenkinsIncrementalsRepoMirror;
-    private URL jenkinsPluginInfo;
-    private boolean doDownload;
-    private boolean useLatestSpecified;
-    private boolean useLatestAll;
-    private boolean skipFailedPlugins;
+    private final String jenkinsWar;
+    private final List<Plugin> plugins;
+    private final boolean verbose;
+    private final HashFunction hashFunction;
+    private final URL jenkinsUc;
+    private final URL jenkinsUcExperimental;
+    private final URL jenkinsIncrementalsRepoMirror;
+    private final URL jenkinsPluginInfo;
+    private final boolean doDownload;
+    private final boolean useLatestSpecified;
+    private final boolean useLatestAll;
+    private final boolean skipFailedPlugins;
+    @NonNull
     private final OutputFormat outputFormat;
     private final List<Credentials> credentials;
+    private final Path cachePath;
+    private final LogOutput logOutput;
 
     private Config(
             File pluginDir,
@@ -72,7 +77,8 @@ public class Config {
             boolean skipFailedPlugins,
             OutputFormat outputFormat,
             HashFunction hashFunction,
-            List<Credentials> credentials) {
+            List<Credentials> credentials,
+            Path cachePath) {
         this.pluginDir = pluginDir;
         this.cleanPluginDir = cleanPluginDir;
         this.showWarnings = showWarnings;
@@ -94,6 +100,8 @@ public class Config {
         this.outputFormat = outputFormat;
         this.credentials = credentials;
         this.hashFunction = hashFunction;
+        this.cachePath = cachePath;
+        this.logOutput = new LogOutput(verbose);
     }
 
     public File getPluginDir() {
@@ -185,6 +193,19 @@ public class Config {
         return hashFunction;
     }
 
+    @NonNull
+    public OutputFormat getOutputFormat() {
+        return outputFormat;
+    }
+
+    public Path getCachePath() {
+        return cachePath;
+    }
+
+    public LogOutput getLogOutput() {
+        return logOutput;
+    }
+
     public static class Builder {
         private File pluginDir;
         private boolean cleanPluginDir;
@@ -207,6 +228,7 @@ public class Config {
         private OutputFormat outputFormat = OutputFormat.STDOUT;
         private List<Credentials> credentials = Collections.emptyList();
         private HashFunction hashFunction = Settings.DEFAULT_HASH_FUNCTION;
+        private Path cachePath = Settings.DEFAULT_CACHE_PATH;
 
         private Builder() {
         }
@@ -328,6 +350,11 @@ public class Config {
             return this;
         }
 
+        public Builder withCachePath(@NonNull Path cachePath) {
+            this.cachePath = cachePath;
+            return this;
+        }
+
         public Config build() {
             return new Config(
                     pluginDir,
@@ -350,7 +377,8 @@ public class Config {
                     skipFailedPlugins,
                     outputFormat,
                     hashFunction,
-                    credentials
+                    credentials,
+                    cachePath
             );
         }
 

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/LogOutput.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/LogOutput.java
@@ -1,0 +1,68 @@
+package io.jenkins.tools.pluginmanager.config;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+/**
+ * Output for user informational messages. Messages are written to standard error so not to interfere with
+ * primary cli output.
+ */
+public class LogOutput {
+
+    private final boolean verbose;
+
+    /**
+     * Create new log output.
+     *
+     * @param verbose true if verbose messages are enabled
+     */
+    public LogOutput(boolean verbose) {
+        this.verbose = verbose;
+    }
+
+    /**
+     * Output message.
+     *
+     * @param message message to output
+     */
+    public void printMessage(String message) {
+        System.err.println(message);
+    }
+
+    /**
+     * Output message if verbose enabled.
+     *
+     * @param message message to output if verbose enabled
+     */
+    public void printVerboseMessage(String message) {
+        if (verbose) {
+            System.err.println(message);
+        }
+    }
+
+    /**
+     * Output message and exception stack trace if verbose enabled.
+     *
+     * @param message message to output if verbose enabled
+     * @param e exception to print stack trace
+     */
+    @SuppressFBWarnings("INFORMATION_EXPOSURE_THROUGH_AN_ERROR_MESSAGE")
+    public void printVerboseMessage(String message, Exception e) {
+        if (verbose) {
+            System.err.println(message);
+            e.printStackTrace(System.err);
+        }
+    }
+
+    /**
+     * Output exception stack trace if verbose enabled.
+     *
+     * @param e exception to print stack trace
+     */
+    @SuppressFBWarnings("INFORMATION_EXPOSURE_THROUGH_AN_ERROR_MESSAGE")
+    public void printVerboseStacktrace(Exception e) {
+        if (verbose) {
+            e.printStackTrace(System.err);
+        }
+    }
+
+}

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginException.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginException.java
@@ -27,7 +27,7 @@ public class PluginException extends RuntimeException {
             // insert in reverse order
             dependencyChain.add(0, currentPlugin);
             if (depth++ > 20) {
-                System.out.println("Probably found a dependency cycle in " + plugin);
+                System.err.println("Probably found a dependency cycle in " + plugin);
                 break;
             }
         }

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/parsers/AvailableUpdatesStdOutPluginOutputConverter.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/parsers/AvailableUpdatesStdOutPluginOutputConverter.java
@@ -1,0 +1,39 @@
+package io.jenkins.tools.pluginmanager.parsers;
+
+import hudson.util.VersionNumber;
+import io.jenkins.tools.pluginmanager.impl.Plugin;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class AvailableUpdatesStdOutPluginOutputConverter implements PluginOutputConverter {
+
+    private final List<Plugin> originalPlugins;
+
+    public AvailableUpdatesStdOutPluginOutputConverter(List<Plugin> originalPlugins) {
+        this.originalPlugins = originalPlugins;
+    }
+
+    @Override
+    public String convert(List<Plugin> plugins) {
+
+        Map<String, Plugin> pluginsAsMap = plugins.stream()
+                .collect(Collectors.toMap(Plugin::getName, plugin -> plugin));
+
+        StringBuilder builder = new StringBuilder("Available updates:\n");
+        for (Plugin plugin : originalPlugins) {
+            VersionNumber originalVersion = plugin.getVersion();
+            VersionNumber newVersion = pluginsAsMap.get(plugin.getName()).getVersion();
+            if (originalVersion.isOlderThan(newVersion)) {
+                builder.append(String.format("%s (%s) has an available update: %s%n", plugin.getName(),
+                        plugin.getVersion(), newVersion));
+            }
+        }
+
+        String result = builder.toString();
+        if (!result.contains("has an")) {
+            return "No available updates\n";
+        }
+        return result;
+    }
+}

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/util/ManifestTools.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/util/ManifestTools.java
@@ -78,7 +78,7 @@ public class ManifestTools {
         try {
             return getAttributesFromManifest(file).getValue(key);
         } catch (IOException e) {
-            System.out.println("Unable to open " + file);
+            System.err.println("Unable to open " + file);
             if (key.equals("Plugin-Dependencies")) {
                 throw new DownloadPluginException("Unable to read " + key + " from the manifest of " + file, e);
             }

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/util/PluginListParser.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/util/PluginListParser.java
@@ -64,7 +64,7 @@ public class PluginListParser {
                         .collect(toList());
                 pluginsFromTxt.addAll(pluginsFromFile);
             } catch (IOException e) {
-                System.out.println("Unable to open " + pluginTxtFile);
+                System.err.println("Unable to open " + pluginTxtFile);
             }
         }
 
@@ -112,7 +112,7 @@ public class PluginListParser {
                     pluginsFromYaml.add(plugin);
                 }
             } catch (IOException e) {
-                System.out.println("Unable to open " + pluginsFromYaml);
+                System.err.println("Unable to open " + pluginsFromYaml);
                 e.printStackTrace();
             }
         }
@@ -131,11 +131,11 @@ public class PluginListParser {
         }
         if (Files.exists(pluginFile.toPath())) {
             if (verbose) {
-                System.out.println("Reading in plugins from " + pluginFile + "\n");
+                System.err.println("Reading in plugins from " + pluginFile + "\n");
             }
             return true;
         }
-        System.out.println(pluginFile + " file does not exist");
+        System.err.println(pluginFile + " file does not exist");
         return false;
     }
 
@@ -168,7 +168,7 @@ public class PluginListParser {
             if (isURL(pluginInfo[2])) {
                 pluginUrl = pluginInfo[2];
             } else {
-                System.out.println("Invalid URL "+ pluginInfo[2] +" , will ignore");
+                System.err.println("Invalid URL " + pluginInfo[2] + " , will ignore");
             }
         }
         return new Plugin(pluginName, pluginVersion, pluginUrl, groupId);

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/config/LogOutputTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/config/LogOutputTest.java
@@ -1,0 +1,75 @@
+package io.jenkins.tools.pluginmanager.config;
+
+import java.util.regex.Pattern;
+import org.apache.commons.lang3.tuple.MutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemErrNormalized;
+import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemOutNormalized;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+public class LogOutputTest {
+
+    private LogOutput verboseEnabled;
+    private LogOutput verboseDisabled;
+
+    @Before
+    public void setUp() {
+        verboseEnabled = new LogOutput(true);
+        verboseDisabled = new LogOutput(false);
+    }
+
+    @Test
+    public void printMessage() {
+        verifyStdErrOnly("foo\n", () -> verboseEnabled.printMessage("foo"));
+        verifyStdErrOnly("foo\n", () -> verboseDisabled.printMessage("foo"));
+    }
+
+    @Test
+    public void printVerboseMessage() {
+        verifyStdErrOnly("foo\n", () -> verboseEnabled.printVerboseMessage("foo"));
+        verifyStdErrOnly("", () -> verboseDisabled.printVerboseMessage("foo"));
+    }
+
+    @Test
+    public void printVerboseMessageWithStackTrace() {
+        Exception e = new Exception("blah");
+        verifyStdErrOnly(Pattern.compile("foo$.java\\.lang\\.Exception: blah$.\\tat io\\.jenkins\\.tools\\.pluginmanager\\.config\\.LogOutputTest\\.printVerboseMessageWithStackTrace.*", Pattern.MULTILINE | Pattern.DOTALL), () -> verboseEnabled.printVerboseMessage("foo", e));
+        verifyStdErrOnly("", () -> verboseDisabled.printVerboseMessage("foo", e));
+    }
+
+    @Test
+    public void printVerboseStacktrace() {
+        Exception e = new Exception("blah");
+        verifyStdErrOnly(Pattern.compile("java\\.lang\\.Exception: blah$.\\tat io\\.jenkins\\.tools\\.pluginmanager\\.config\\.LogOutputTest\\.printVerboseStacktrace.*", Pattern.MULTILINE | Pattern.DOTALL), () -> verboseEnabled.printVerboseStacktrace(e));
+        verifyStdErrOnly("", () -> verboseDisabled.printVerboseStacktrace(e));
+    }
+
+    static void verifyStdErrOnly(String expected, Runnable statement) {
+        Pair<String, String> output = tapOutput(statement);
+        assertThat(output.getLeft()).isEmpty();
+        assertThat(output.getRight()).isEqualTo(expected);
+    }
+
+    static void verifyStdErrOnly(Pattern expected, Runnable statement) {
+        Pair<String, String> output = tapOutput(statement);
+        assertThat(output.getLeft()).isEmpty();
+        assertThat(output.getRight()).matches(expected);
+    }
+
+    private static Pair<String, String> tapOutput(Runnable statement) {
+        try {
+            final MutablePair<String, String> output = new MutablePair<>();
+            output.setLeft(tapSystemOutNormalized(() -> {
+                output.setRight(tapSystemErrNormalized(statement::run));
+            }));
+            return output;
+        } catch (Exception e) {
+            fail(e.getMessage());
+            return Pair.of("", "");
+        }
+    }
+}

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerIntegrationTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerIntegrationTest.java
@@ -60,12 +60,12 @@ public class PluginManagerIntegrationTest {
                 .withPluginDir(pluginsDir)
                 .withShowAvailableUpdates(true)
                 .withIsVerbose(true)
-                .withDoDownload(false);
+                .withDoDownload(false)
+                .withCachePath(cacheDir.toPath());
         configurator.configure(configBuilder);
         Config config = configBuilder.build();
 
         PluginManager pluginManager = new PluginManager(config);
-        pluginManager.setCm(new CacheManager(cacheDir.toPath(), true, false));
         pluginManager.setLatestUcJson(latestUcJson);
         pluginManager.setLatestUcPlugins(latestUcJson.getJSONObject("plugins"));
         pluginManager.setPluginInfoJson(pluginManager.getJson(pluginVersionsFile.toURI().toURL(), "plugin-versions"));

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerWiremockTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerWiremockTest.java
@@ -33,7 +33,7 @@ public class PluginManagerWiremockTest {
     public final TemporaryFolder folder = new TemporaryFolder();
 
     @Before
-    public void proxyToWireMock() {
+    public void proxyToWireMock() throws IOException {
         archives = new WireMockServer(WireMockConfiguration.options().dynamicPort().notifier(new ConsoleNotifier(true)));
         archives.start();
         protectedArchives = new WireMockServer(WireMockConfiguration.options().dynamicPort().notifier(new ConsoleNotifier(true)));
@@ -42,6 +42,7 @@ public class PluginManagerWiremockTest {
                 .withJenkinsWar(Settings.DEFAULT_WAR)
                 .withPluginDir(new File(folder.getRoot(), "plugins"))
                 .withCredentials(Collections.singletonList(new Credentials("myuser", "mypassword", "localhost", protectedArchives.port())))
+                .withCachePath(folder.newFolder().toPath())
                 .build();
         pm = new PluginManager(cfg);
 
@@ -84,7 +85,6 @@ public class PluginManagerWiremockTest {
     @Test
     public void getJsonWithBasicAuth() throws IOException{
         int wireMockPort = protectedArchives.port();
-        pm.setCm(new CacheManager(folder.newFolder().toPath(), false));
         assertThat(pm.getJson(new URL("http://localhost:" + wireMockPort + "/update-center.json"), "cache-key")).isNotNull();
     }
 

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/parsers/AvailableUpdatesStdOutPluginOutputConverterTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/parsers/AvailableUpdatesStdOutPluginOutputConverterTest.java
@@ -1,0 +1,33 @@
+package io.jenkins.tools.pluginmanager.parsers;
+
+import io.jenkins.tools.pluginmanager.impl.Plugin;
+import java.util.List;
+import org.junit.Test;
+
+import static java.lang.String.format;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AvailableUpdatesStdOutPluginOutputConverterTest extends BaseParserTest {
+
+    @Test
+    public void convert() {
+        List<Plugin> originalPlugins = singletonList(plugin("mailer", "1.31"));
+        List<Plugin> latestVersionsOfPlugins = pm.getLatestVersionsOfPlugins(originalPlugins);
+
+        String converted = new AvailableUpdatesStdOutPluginOutputConverter(originalPlugins).convert(latestVersionsOfPlugins);
+        assertThat(converted.trim().replaceAll("\r\n", "\n"))
+                .isEqualTo(format("Available updates:%n" +
+                        "mailer (1.31) has an available update: 1.32.1%n").trim().replaceAll("\r\n", "\n"));
+    }
+
+    @Test
+    public void convertNoUpdated() {
+        List<Plugin> originalPlugins = singletonList(plugin("mailer", "1.32.1"));
+        List<Plugin> latestVersionsOfPlugins = pm.getLatestVersionsOfPlugins(originalPlugins);
+
+        String converted = new AvailableUpdatesStdOutPluginOutputConverter(originalPlugins).convert(latestVersionsOfPlugins);
+        assertThat(converted)
+                .isEqualTo("No available updates\n");
+    }
+}

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/parsers/StdOutPluginOutputConverterTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/parsers/StdOutPluginOutputConverterTest.java
@@ -1,10 +1,10 @@
 package io.jenkins.tools.pluginmanager.parsers;
 
 import io.jenkins.tools.pluginmanager.impl.Plugin;
+import java.util.Collections;
 import java.util.List;
 import org.junit.Test;
 
-import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -12,22 +12,16 @@ public class StdOutPluginOutputConverterTest extends BaseParserTest {
 
     @Test
     public void convert() {
-        List<Plugin> originalPlugins = singletonList(plugin("mailer", "1.31"));
-        List<Plugin> latestVersionsOfPlugins = pm.getLatestVersionsOfPlugins(originalPlugins);
-
-        String converted = new StdOutPluginOutputConverter(originalPlugins).convert(latestVersionsOfPlugins);
-        assertThat(converted.trim().replaceAll("\r\n", "\n"))
-                .isEqualTo(format("Available updates:%n" +
-                        "mailer (1.31) has an available update: 1.32.1%n").trim().replaceAll("\r\n", "\n"));
+        List<Plugin> plugins = singletonList(plugin("mailer", "1.31"));
+        String converted = new StdOutPluginOutputConverter("Plugins").convert(plugins);
+        assertThat(converted)
+                .isEqualTo(String.format("Plugins%nmailer 1.31%n"));
     }
 
     @Test
-    public void convertNoUpdated() {
-        List<Plugin> originalPlugins = singletonList(plugin("mailer", "1.32.1"));
-        List<Plugin> latestVersionsOfPlugins = pm.getLatestVersionsOfPlugins(originalPlugins);
-
-        String converted = new StdOutPluginOutputConverter(originalPlugins).convert(latestVersionsOfPlugins);
+    public void covertEmptyList() {
+        String converted = new StdOutPluginOutputConverter("Plugins").convert(Collections.emptyList());
         assertThat(converted)
-                .isEqualTo("No available updates\n");
+                .isEqualTo(String.format("Plugins%n-none-%n"));
     }
 }


### PR DESCRIPTION
Direct cli user messages to standard error rather than standard out. Standard out
is reserved for primary output, which in cases like `--list --output yaml` would
be the yaml formatted plugin list. This separation of output is consistent with
general cli guidelines, https://clig.dev/#the-basics.

Fixes: #377 
Fixes #284
Fixes #227

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
