### PR TITLE
Backup existing plugins when updating

### DIFF
--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/Plugin.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/Plugin.java
@@ -98,6 +98,8 @@ public class Plugin {
         return name + ".jpi";
     }
 
+    public String getBackupFileName() { return name + ".bak"; }
+
     public File getFile() {
         return file;
     }

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -605,10 +605,14 @@ public class PluginManager implements Closeable {
                 }
                 // We do not double-check overrides here, because findPluginsToDownload() has already done it
                 File finalPath = new File(pluginDir, archiveName);
+                File backupPath = new File(pluginDir, plugin.getBackupFileName());
                 if (finalPath.isDirectory()) {
                     // Jenkins supports storing plugins as unzipped files with ".jpi" extension
                     FileUtils.cleanDirectory(finalPath);
                     Files.delete(finalPath.toPath());
+                }
+                if (finalPath.exists()) {
+                    Files.move(finalPath.toPath(), backupPath.toPath(), StandardCopyOption.REPLACE_EXISTING);
                 }
                 Files.move(downloadedPlugin.toPath(), finalPath.toPath(), StandardCopyOption.REPLACE_EXISTING);
             } catch (IOException ex) {

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerIntegrationTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerIntegrationTest.java
@@ -29,6 +29,7 @@ import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemOut;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -340,6 +341,33 @@ public class PluginManagerIntegrationTest {
 
         // Ensure that the plugins are actually in place
         assertPluginInstalled(trileadAPI);
+    }
+
+    @Test
+    public void verifyBackups() throws Exception {
+
+        // First cycle, empty dir
+        Plugin initialTrileadAPI = new Plugin("trilead-api", "1.0.12", null, null);
+        File pluginArchive = new File(pluginsDir, initialTrileadAPI.getArchiveFileName());
+        File pluginBackup = new File(pluginsDir, initialTrileadAPI.getBackupFileName());
+        List<Plugin> requestedPlugins_1 = Collections.singletonList(initialTrileadAPI);
+        PluginManager pluginManager = initPluginManager(
+                configBuilder -> configBuilder.withPlugins(requestedPlugins_1).withDoDownload(true));
+        pluginManager.start();
+        assertPluginInstalled(initialTrileadAPI);
+        assertFalse(pluginBackup.exists());
+
+
+        // Second cycle, with plugin update and new plugin installation
+        Plugin trileadAPI = new Plugin("trilead-api", "1.0.13", null, null);
+        List<Plugin> requestedPlugins_2 = Collections.singletonList(trileadAPI);
+        PluginManager pluginManager2 = initPluginManager(
+                configBuilder -> configBuilder.withPlugins(requestedPlugins_2).withDoDownload(true));
+        pluginManager2.start();
+
+        // Ensure that the plugins are actually in place and backup now exists
+        assertPluginInstalled(trileadAPI);
+        assertTrue(pluginBackup.exists());
     }
 
     //TODO: Enable as auto-test once it can run without big traffic overhead (15 plugin downloads)


### PR DESCRIPTION
Makes the plugin manages backup existing plugins to allow rollback within the Jenkins UI. 
Fixes #310 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

I'm not sure if this should have a cli option to switch this on/off.
