### PR TITLE
Improve documentation proxy settings example

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Proxy support is available using standard [Java networking system properties](ht
 
 ```bash
 # Example using proxy system properties
-java -Dhttp.proxyPort=3128 -Dhttp.proxyHost=myproxy.example.com -jar jenkins-plugin-manager-*.jar
+java -Dhttp.proxyPort=3128 -Dhttp.proxyHost=myproxy.example.com -Dhttps.proxyPort=3128 -Dhttps.proxyHost=myproxy.example.com -jar jenkins-plugin-manager-*.jar
 ```
 
 


### PR DESCRIPTION
While migrating from install-plugins.sh to jenkins-plugin-manager the documentation was insufficient to setup the proxy configuration. This pull request improves the documentation example with the correct proxy settings that are required.
I first created issue https://github.com/jenkinsci/plugin-installation-manager-tool/issues/450 but it isn't a bug but rather incomplete documentation.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
