### PR TITLE
Remove redundant `project.build.sourceEncoding` property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,6 @@
         <revision>2.12.9</revision>
         <changelist>-SNAPSHOT</changelist>
         <java.level>8</java.level>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spotbugs.excludeFilterFile>${project.basedir}/../src/spotbugs/spotbugs-excludes.xml</spotbugs.excludeFilterFile>
         <tagNameFormat>@{project.version}</tagNameFormat>
     </properties>


### PR DESCRIPTION
This has been in the parent POM since https://github.com/jenkinsci/pom/pull/257 which was released in 1.76.