### PR TITLE
Remove deprecated `java.level` property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,6 @@
     <properties>
         <revision>2.12.9</revision>
         <changelist>-SNAPSHOT</changelist>
-        <java.level>8</java.level>
         <spotbugs.excludeFilterFile>${project.basedir}/../src/spotbugs/spotbugs-excludes.xml</spotbugs.excludeFilterFile>
         <tagNameFormat>@{project.version}</tagNameFormat>
     </properties>


### PR DESCRIPTION
This property was deprecated in jenkinsci/pom#245.