### PR TITLE
Use `maven.multiModuleProjectDirectory` where possible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <revision>2.12.9</revision>
         <changelist>-SNAPSHOT</changelist>
         <java.level>8</java.level>
-        <spotbugs.excludeFilterFile>${project.basedir}/../src/spotbugs/spotbugs-excludes.xml</spotbugs.excludeFilterFile>
+        <spotbugs.excludeFilterFile>${maven.multiModuleProjectDirectory}/src/spotbugs/spotbugs-excludes.xml</spotbugs.excludeFilterFile>
         <tagNameFormat>@{project.version}</tagNameFormat>
     </properties>
 


### PR DESCRIPTION
Cleaner than using relative paths and consistent with our usage in Jenkins core.