### PR TITLE
Fix plugin installation when using `--clean-download-directory`

### DIFF
--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -211,7 +211,7 @@ public class PluginManager implements Closeable {
                 throw new UncheckedIOException("Unable to delete: " + pluginDir.getAbsolutePath(), e);
             }
         }
-        if (cfg.doDownload()) {
+        if (cfg.doDownload() && !pluginDir.exists()) {
             createPluginDir(cfg.isCleanPluginDir());
         }
 


### PR DESCRIPTION
Fixes: https://github.com/jenkinsci/plugin-installation-manager-tool/issues/379

I stumbled upon the same when trying to clean up the `plugins` directory to handle Jenkins' rollback, for example.
Updating the conditional should fix the plugin installation process when using `--clean-download-directory` (which is cleaning the directory contents, not removing the directory itself).

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
