### PR TITLE
Update snakeyaml dependency to resolve CVEs

### DIFF
--- a/plugin-management-library/pom.xml
+++ b/plugin-management-library/pom.xml
@@ -13,17 +13,6 @@
     <version>${revision}${changelist}</version>
     <packaging>jar</packaging>
 
-    <dependencyManagement>
-        <dependencies>
-            <!-- TODO: Remove when jackson dataformat snakeyaml dependency is at least 1.32 -->
-            <dependency>
-                <groupId>org.yaml</groupId>
-                <artifactId>snakeyaml</artifactId>
-                <version>1.32</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci</groupId>
@@ -75,6 +64,12 @@
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>2.13.4</version>
+        </dependency>
+        <!-- TODO: Remove when jackson dataformat snakeyaml dependency is at least 1.32 -->
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>1.32</version>
         </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>

--- a/plugin-management-library/pom.xml
+++ b/plugin-management-library/pom.xml
@@ -13,6 +13,17 @@
     <version>${revision}${changelist}</version>
     <packaging>jar</packaging>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- TODO: Remove when jackson dataformat snakeyaml dependency is at least 1.32 -->
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>1.32</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci</groupId>

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerIntegrationTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerIntegrationTest.java
@@ -298,7 +298,7 @@ public class PluginManagerIntegrationTest {
 
         // Second cycle, with plugin update and new plugin installation
         Plugin trileadAPI = new Plugin("trilead-api", "1.0.13", null, null);
-        Plugin snakeYamlAPI = new Plugin("snakeyaml-api", "1.27.0", null, null);
+        Plugin snakeYamlAPI = new Plugin("snakeyaml-api", "1.31-84.ve43da_fb_49d0b", null, null);
         List<Plugin> requestedPlugins_2 = Arrays.asList(trileadAPI, snakeYamlAPI);
         PluginManager pluginManager2 = initPluginManager(
                 configBuilder -> configBuilder.withPlugins(requestedPlugins_2).withDoDownload(true));

--- a/plugin-management-library/src/test/resources/io/jenkins/tools/pluginmanager/impl/plugins.txt
+++ b/plugin-management-library/src/test/resources/io/jenkins/tools/pluginmanager/impl/plugins.txt
@@ -46,7 +46,7 @@ role-strategy:2.16
 run-condition:1.3
 scm-api:2.6.3
 security-inspector:0.5
-snakeyaml-api:1.26.4
+snakeyaml-api:1.31-84.ve43da_fb_49d0b
 ssh-credentials:1.18.1
 timestamper:1.11.3
 token-macro:2.12

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,11 @@
                 <artifactId>slf4j-api</artifactId>
                 <version>2.0.1</version>
             </dependency>
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>1.32</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     

--- a/pom.xml
+++ b/pom.xml
@@ -73,15 +73,9 @@
                 <artifactId>slf4j-api</artifactId>
                 <version>2.0.1</version>
             </dependency>
-            <!-- TODO: Remove this when jackson dataformat updates their snakeyaml dependency to at least 1.32 -->
-            <dependency>
-                <groupId>org.yaml</groupId>
-                <artifactId>snakeyaml</artifactId>
-                <version>1.32</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
-    
+
     <dependencies>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
+    
     <dependencies>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
                 <artifactId>slf4j-api</artifactId>
                 <version>2.0.1</version>
             </dependency>
+            <!-- TODO: Remove this when jackson dataformat updates their snakeyaml dependency to at least 1.32 -->
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>


### PR DESCRIPTION
Fixes: https://github.com/jenkinsci/plugin-installation-manager-tool/issues/479

There are a number of vulnerabilities in snakeyaml, which we inherit from our dependency on snakeyaml, namely:

- CVE-2022-38749
- CVE-2022-38750
- CVE-2022-25857
- CVE-2022-38751
- CVE-2022-38752

Most of these have been resolved in snakeyaml v1.32 or 1.31.

The changes in this PR are to upgrade to the latest snakeyaml library to avail of the fix.

Local testing:

```bash
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for plugin-management-parent-pom 2.12.10-SNAPSHOT:
[INFO]
[INFO] plugin-management-parent-pom ....................... SUCCESS [  5.837 s]
[INFO] plugin-management-library .......................... SUCCESS [01:38 min]
[INFO] plugin-management-cli .............................. SUCCESS [ 11.598 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:56 min
[INFO] Finished at: 2022-09-22T13:10:49+01:00
[INFO] ------------------------------------------------------------------------
```

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue


