### PR TITLE
Configure explicit line termination for source files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+* text eol=lf
+
+# Binary files stored in the repository
+*.hpi binary
+*.jpi binary
+*.war binary
+*.zip binary


### PR DESCRIPTION
## Configure explicit line termination for source files

Windows users that checkout with `autocrlf=true` would get Java source files that use CRLF line termination and then the formatting checks will fail due to the CRLF line termination.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
