### PR TITLE
Enable ci.jenkins.io coverage reporting

### DIFF
--- a/plugin-management-cli/pom.xml
+++ b/plugin-management-cli/pom.xml
@@ -27,12 +27,6 @@
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
             <optional>true</optional>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.code.findbugs</groupId>
-                    <artifactId>jsr305</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.github.stefanbirkner</groupId>

--- a/plugin-management-library/pom.xml
+++ b/plugin-management-library/pom.xml
@@ -75,12 +75,6 @@
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
             <optional>true</optional>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.code.findbugs</groupId>
-                    <artifactId>jsr305</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.github.tomakehurst</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -137,4 +137,39 @@
         </resources>
     </build>
 
+    <profiles>
+        <profile>
+            <id>enable-jacoco</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+			<version>0.8.8</version>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/Messages.class</exclude>
+                                <!-- https://github.com/HtmlUnit/htmlunit-cssparser/issues/4 -->
+                                <exclude>com/gargoylesoftware/**</exclude>
+                            </excludes>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>report</id>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>


### PR DESCRIPTION
## Enable coverage reporting on ci.jenkins.io

- Add enable-jacoco profile for coverage reporting
- Fix javadoc generation by not excluding jsr305

Also fixes a javadoc generation warning but removing the exclusion of the jsr305 dependency from spotbugs annotations.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

## Testing done

Compare the [job before this change](https://ci.jenkins.io/job/Tools/job/plugin-installation-manager-tool/job/master/lastSuccessfulBuild/) (no coverage report) and the [pull request build](https://ci.jenkins.io/job/Tools/job/plugin-installation-manager-tool/view/change-requests/job/PR-524/lastSuccessfulBuild/) with its [coverage report](https://ci.jenkins.io/job/Tools/job/plugin-installation-manager-tool/view/change-requests/job/PR-524/lastSuccessfulBuild/coverage/)

![screencapture-ci-jenkins-io-job-Tools-job-plugin-installation-manager-tool-view-change-requests-job-PR-524-lastSuccessfulBuild-coverage-2023-02-02-13_34_32-edit](https://user-images.githubusercontent.com/156685/216443632-28bba39b-b8cd-49b7-b809-de9022d67854.png)

## Requested reviewers

I'd love to have a review from one or more of the people in the GSoC mentoring prep meeting, including @freyam, @krisstern , @gounthar , or @jmMeessen .  Reviews not strictly required, but would be nice.