### PR TITLE
Show security heading only if warnings exist

### DIFF
--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -459,9 +459,13 @@ public class PluginManager implements Closeable {
         // NOTE: By default, the plugin installation manager tool will show security warnings.
         // see: https://github.com/jenkinsci/plugin-installation-manager-tool/issues/258
         if (!cfg.isHideWarnings()) {
-            logMessage("\nSecurity warnings:");
+            boolean headingDisplayed = false;
             for (Plugin plugin : plugins) {
                 if (warningExists(plugin)) {
+                    if (!headingDisplayed) {
+                        logMessage("\nSecurity warnings:");
+                        headingDisplayed = true;
+                    }
                     String pluginName = plugin.getName();
                     logMessage(plugin.getSecurityWarnings().stream()
                             .map(warning -> String.format("%s (%s): %s %s %s", pluginName,


### PR DESCRIPTION
## Only show security heading if there is a security warning

Test highlights that there is ambiguity in the tested code because there are two booleans to represent a single condition.  It is possible to have hideWarning == true and showWarning == true, even though we can only do one or the other but not both.

Another pull request or another change in this pull request will need to resolve that issue in the most recently merged pull request.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
