### PR TITLE
[Improve code readability] Replace the two boolean variables that control the visibility of security warnings with a single boolean variable (#537)

### DIFF
--- a/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/CliOptions.java
+++ b/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/CliOptions.java
@@ -310,7 +310,7 @@ class CliOptions {
      * @return true if user selected CLI Option to see warnings for specified plugins
      */
     private boolean isShowWarnings() {
-        return showWarnings;
+        return !hideWarnings;
     }
 
     /**

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Config.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Config.java
@@ -24,7 +24,6 @@ import java.util.List;
 public class Config {
     private final File pluginDir;
     private final boolean cleanPluginDir;
-    private final boolean showWarnings;
     private final boolean hideWarnings;
     private final boolean showAllWarnings;
     private final boolean showAvailableUpdates;
@@ -60,7 +59,6 @@ public class Config {
     private Config(
             File pluginDir,
             boolean cleanPluginDir,
-            boolean showWarnings,
             boolean showAllWarnings,
             boolean showAvailableUpdates,
             boolean showPluginsToBeDownloaded,
@@ -83,7 +81,6 @@ public class Config {
             boolean hideWarnings) {
         this.pluginDir = pluginDir;
         this.cleanPluginDir = cleanPluginDir;
-        this.showWarnings = showWarnings;
         this.showAllWarnings = showAllWarnings;
         this.showAvailableUpdates = showAvailableUpdates;
         this.showPluginsToBeDownloaded = showPluginsToBeDownloaded;
@@ -116,7 +113,7 @@ public class Config {
     }
 
     public boolean isShowWarnings() {
-        return showWarnings;
+        return !hideWarnings;
     }
 
     public boolean isHideWarnings() {
@@ -216,7 +213,6 @@ public class Config {
     public static class Builder {
         private File pluginDir;
         private boolean cleanPluginDir;
-        private boolean showWarnings;
         private boolean hideWarnings;
         private boolean showAllWarnings;
         private boolean showAvailableUpdates;
@@ -252,7 +248,7 @@ public class Config {
         }
 
         public Builder withShowWarnings(boolean showWarnings) {
-            this.showWarnings = showWarnings;
+            this.hideWarnings = !showWarnings;
             return this;
         }
 
@@ -372,7 +368,6 @@ public class Config {
             return new Config(
                     pluginDir,
                     cleanPluginDir,
-                    showWarnings,
                     showAllWarnings,
                     showAvailableUpdates,
                     showPluginsToBeDownloaded,


### PR DESCRIPTION
Fixes #537

[Improve code readability] Replace the two boolean variables that control the visibility of security warnings with a single boolean variable (#537)
- Delete the old internal variable `showWarnings` and its existing getter read the negated value of the new variable `hideWarnings`.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
