### PR TITLE
feat: sort the YAML output by name and version

### DIFF
--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/parsers/YamlPluginOutputConverter.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/parsers/YamlPluginOutputConverter.java
@@ -12,6 +12,8 @@ import io.jenkins.tools.pluginmanager.util.Source;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static java.util.Comparator.comparing;
+
 public class YamlPluginOutputConverter implements PluginOutputConverter {
     @Override
     public String convert(List<Plugin> plugins) {
@@ -28,6 +30,7 @@ public class YamlPluginOutputConverter implements PluginOutputConverter {
 
     private Plugins mapToOutputFormat(List<Plugin> plugins) {
         List<PluginInfo> convertedPlugins = plugins.stream()
+                .sorted(comparing(Plugin::getName).thenComparing(Plugin::getVersion))
                 .map(this::toPluginHolder)
                 .collect(Collectors.toList());
 

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
@@ -363,10 +363,22 @@ public class PluginManagerTest {
                         "plugin2 2.0\n\n");
 
         assertThat(stdOutput).isEqualTo("plugins:\n" +
-                "- artifactId: \"installed2\"\n" +
+                "- artifactId: \"bundled1\"\n" +
+                "  source:\n" +
+                "    version: \"1.0\"\n" +
+                "- artifactId: \"bundled2\"\n" +
                 "  source:\n" +
                 "    version: \"2.0\"\n" +
-                "- artifactId: \"bundled2\"\n" +
+                "- artifactId: \"dependency1\"\n" +
+                "  source:\n" +
+                "    version: \"1.0.0\"\n" +
+                "- artifactId: \"dependency2\"\n" +
+                "  source:\n" +
+                "    version: \"1.0.0\"\n" +
+                "- artifactId: \"installed1\"\n" +
+                "  source:\n" +
+                "    version: \"1.0\"\n" +
+                "- artifactId: \"installed2\"\n" +
                 "  source:\n" +
                 "    version: \"2.0\"\n" +
                 "- artifactId: \"plugin1\"\n" +
@@ -375,18 +387,7 @@ public class PluginManagerTest {
                 "- artifactId: \"plugin2\"\n" +
                 "  source:\n" +
                 "    version: \"2.0\"\n" +
-                "- artifactId: \"bundled1\"\n" +
-                "  source:\n" +
-                "    version: \"1.0\"\n" +
-                "- artifactId: \"installed1\"\n" +
-                "  source:\n" +
-                "    version: \"1.0\"\n" +
-                "- artifactId: \"dependency2\"\n" +
-                "  source:\n" +
-                "    version: \"1.0.0\"\n" +
-                "- artifactId: \"dependency1\"\n" +
-                "  source:\n" +
-                "    version: \"1.0.0\"\n\n");
+                "\n");
     }
 
     @Test


### PR DESCRIPTION
## Summary

In order to be able to _quickly_ compare the list of plugins across our Jenkins instances, I added sorting to the `YamlPluginOutputConverter`.

Please let me know if you would like me to also add sorting capabilities elsewhere.

# Manual testing

## Given

My local development Jenkins instance, I installed some plugins to test with.

## When

I ran the last released version (2.12.11):

`java -jar path/to/jenkins-plugin-manager-2.12.11.jar --war "${JENKINS_HOME}/jenkins.war" --plugin-download-directory "${JENKINS_HOME}/plugins" --list --output yaml > plugins-2.12.11.yaml`

## Then

I obtained the baseline output in a `plugins-2.12.11.yaml` file.

## When

I ran the version with these changes:

`java -jar path/to/jenkins-plugin-manager-2.12.12-SNAPSHOT.jar --war "${JENKINS_HOME}/jenkins.war" --plugin-download-directory "${JENKINS_HOME}/plugins" --list --output yaml > plugins-2.12.12-SNAPSHOT.yaml`

## Then

I obtained the new and improved output in a `plugins-2.12.12-SNAPSHOT.yaml` file.

Comparing the baseline to it with a graphical diff tool (Meld), we see the old-and-busted version on the left and the new hotness on the right, where we clearly have an alphabetically-sorted list on the right:

![comparing_unsorted_with_sorted_yaml](https://github.com/jenkinsci/plugin-installation-manager-tool/assets/297515/597d850c-0bf5-4ee8-b558-6c48c6b6f7cf)

Mission accomplished!