### PR TITLE
chore(GHA) use `gh` CLI to publish artefact to release

### DIFF
--- a/.github/workflows/publish-release-artifact.yml
+++ b/.github/workflows/publish-release-artifact.yml
@@ -33,9 +33,6 @@ jobs:
             -O $FILE_NAME-$PROJECT_VERSION.jar
       - name: Upload Release Asset
         id: upload-release-asset
-        uses: actions/upload-asset@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          path: ./${{ steps.fetch-artifact.outputs.file-name }}-${{ steps.set-version.outputs.project-version }}.jar
-          name: ${{ steps.fetch-artifact.outputs.file-name }}-${{ steps.set-version.outputs.project-version }}.jar
+        run: gh release upload ${{ steps.set-version.outputs.project-version }} ./${{ steps.fetch-artifact.outputs.file-name }}-${{ steps.set-version.outputs.project-version }}.jar


### PR DESCRIPTION
This PR is a response to https://github.com/jenkinsci/plugin-installation-manager-tool/issues/577

It uses the `gh` CLI to upload artefact to the freshly published GitHub release instead of using a GitHub actions.

The reasons are:

- https://github.com/actions/upload-release-asset is archived (causing #577)
- There are no more certified action that upload files (only 3rd party)
- The `gh` CLI is [pre-installed iun the GitHub runners](https://docs.github.com/en/actions/using-workflows/using-github-cli-in-workflows)

### Testing done

Not really tested as it is a release process 😅

It's been directly written from the reference doc at https://cli.github.com/manual/gh_release_upload

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
