### PR TITLE
Updated jenkins.war default path for linux

### DIFF
--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Settings.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Settings.java
@@ -50,7 +50,7 @@ public class Settings {
             DEFAULT_WAR = "C:\\ProgramData\\Jenkins\\jenkins.war";
             DEFAULT_PLUGIN_DIR_LOCATION = "C:\\ProgramData\\Jenkins\\Reference\\Plugins";
         } else {
-            DEFAULT_WAR = "/usr/share/jenkins/jenkins.war";
+            DEFAULT_WAR = "/usr/share/java/jenkins.war";
             DEFAULT_PLUGIN_DIR_LOCATION = "/usr/share/jenkins/ref/plugins";
         }
     }


### PR DESCRIPTION
Fixes #427 
Fixes https://github.com/jenkinsci/plugin-installation-manager-tool/pull/520

This PR changed the default jenkins.war location for OS other than windows to usr/share/java/jenkins.war  
### Operating System used
Linux: Ubuntu

### Issue Reproduction Steps
Same as described in the issue description

### Expected Result is Achieved
plugin installation manager tool finds jenkins.war at the default path and is able to get the Jenkins version from it.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue


<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
