### PR TITLE
Updated default war file location in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ exit
 * `--jenkins-version`: (optional) Version of Jenkins to be used.
   If not specified, the plugin manager will try to extract it from the WAR file or other sources.
   The argument can be also set using the `JENKINS_VERSION` environment variable.
-* `--war` or `-w`: (optional) Path to Jenkins war file. If no war file is entered, will default to /usr/share/jenkins/jenkins.war or C:\ProgramData\Jenkins\jenkins.war, depending on the user's OS. Plugins that are already included in the Jenkins war will only be downloaded if their required version is newer than the one included.
+* `--war` or `-w`: (optional) Path to Jenkins war file. If no war file is entered, it will default to a specific location based on user's OS. In case of Windows, it will default to C:\ProgramData\Jenkins\jenkins.war and in case of OS other than Windows, it will default to /usr/share/java/jenkins.war. Plugins that are already included in the Jenkins war will only be downloaded if their required version is newer than the one included.
 * `--list` or `-l`: (optional) Lists plugin names and versions of: installed plugins (plugins that already exist in the plugin directory), bundled plugins (non-detached plugins that exist in the war file), plugins that will be downloaded (highest required versions of the requested plugins and dependencies that are not already installed), and the effective plugin set (the highest versions of all plugins that are already installed or will be installed)
 * `--verbose`: (optional) Show additional information about plugin dependencies and the download process
 * `--hide-security-warnings`: (optional) Hide if any of the user specified plugins have security warnings

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Settings.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Settings.java
@@ -50,7 +50,7 @@ public class Settings {
             DEFAULT_WAR = "C:\\ProgramData\\Jenkins\\jenkins.war";
             DEFAULT_PLUGIN_DIR_LOCATION = "C:\\ProgramData\\Jenkins\\Reference\\Plugins";
         } else {
-            DEFAULT_WAR = "/usr/share/jenkins/jenkins.war";
+            DEFAULT_WAR = "/usr/share/java/jenkins.war";
             DEFAULT_PLUGIN_DIR_LOCATION = "/usr/share/jenkins/ref/plugins";
         }
     }


### PR DESCRIPTION
Fixes #427 
Fixes #622

Made relevant changes required in the README.md i.e the default location of the war file in README.md is updated. 

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
