### PR TITLE
implementing --skip-broken option

### DIFF
--- a/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/CliOptions.java
+++ b/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/CliOptions.java
@@ -155,6 +155,9 @@ class CliOptions {
             handler = MultiCredentialsOptionHandler.class)
     private List<Credentials> credentials;
 
+    @Option(name = "--skip-broken", usage = "Lists skipped plugins when enabled", handler = BooleanOptionHandler.class)
+    private boolean skipBroken;
+
     /**
      * Creates a configuration class with configurations specified from the CLI and/or environment variables.
      *
@@ -184,6 +187,7 @@ class CliOptions {
                 .withSkipFailedPlugins(isSkipFailedPlugins())
                 .withCredentials(credentials)
                 .withHashFunction(getHashFunction())
+                .withSkipBroken(isSkipBroken())
                 .build();
     }
 
@@ -341,6 +345,15 @@ class CliOptions {
 
     public boolean isVerbose() {
         return verbose;
+    }
+
+    /**
+     * Gets the value corresponding to if user selected to list skipped plugins
+     *
+     * @return true if user selected CLI Option to list skipped plugins
+     */
+    private boolean isSkipBroken() {
+        return skipBroken;
     }
 
     /**

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Config.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Config.java
@@ -56,6 +56,7 @@ public class Config {
     private final List<Credentials> credentials;
     private final Path cachePath;
     private final LogOutput logOutput;
+    private final boolean skipBroken;
 
     private Config(
             File pluginDir,
@@ -80,7 +81,8 @@ public class Config {
             HashFunction hashFunction,
             List<Credentials> credentials,
             Path cachePath,
-            boolean hideWarnings) {
+            boolean hideWarnings,
+            boolean skipBroken) {
         this.pluginDir = pluginDir;
         this.cleanPluginDir = cleanPluginDir;
         this.showWarnings = showWarnings;
@@ -105,6 +107,7 @@ public class Config {
         this.cachePath = cachePath;
         this.logOutput = new LogOutput(verbose);
         this.hideWarnings = hideWarnings;
+        this.skipBroken = skipBroken;
     }
 
     public File getPluginDir() {
@@ -213,6 +216,10 @@ public class Config {
         return logOutput;
     }
 
+    public boolean isSkipBroken(){
+        return skipBroken;
+    }
+
     public static class Builder {
         private File pluginDir;
         private boolean cleanPluginDir;
@@ -237,6 +244,7 @@ public class Config {
         private List<Credentials> credentials = Collections.emptyList();
         private HashFunction hashFunction = Settings.DEFAULT_HASH_FUNCTION;
         private Path cachePath = Settings.DEFAULT_CACHE_PATH;
+        private boolean skipBroken;
 
         private Builder() {
         }
@@ -368,6 +376,11 @@ public class Config {
             return this;
         }
 
+        public Builder withSkipBroken(Boolean skipBroken){
+            this.skipBroken = skipBroken;
+            return this;
+        }
+
         public Config build() {
             return new Config(
                     pluginDir,
@@ -392,7 +405,8 @@ public class Config {
                     hashFunction,
                     credentials,
                     cachePath,
-                    hideWarnings
+                    hideWarnings,
+                    skipBroken
             );
         }
 

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -242,6 +242,18 @@ public class PluginManager implements Closeable {
         if (cfg.doDownload()) {
             downloadPlugins(pluginsToBeDownloaded);
         }
+        if(cfg.isSkipBroken()){
+            List<Plugin> failedPlugins = getFailedPlugins();
+            if(failedPlugins.isEmpty()){
+                System.out.println("No plugin is skipped");
+            }
+            else{
+                System.out.println("Following plugins are skipped due to failure:");
+                for(Plugin failedPlugin: failedPlugins){
+                    System.out.println(failedPlugin.getName());
+                }
+            }
+        }
         logMessage("Done");
     }
 


### PR DESCRIPTION
fixes #428 

This is an attempt to implement --skip-broken options which  need to display the list of failed plugins when enabled.  Need insights from maintainers as the expected behaviour is not achieved. It works fine only when none of the plugins fails to download. In that case it prints out "No plugin is skipped". 

## Approach
A new option named --skip-broken is created. Necessary flags are created for this option. Now when this option is enabled we fetch the list of failed plugins using getFailedPlugins().


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

