### PR TITLE
Generating plugins lock file

### DIFF
--- a/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/CliOptions.java
+++ b/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/CliOptions.java
@@ -18,6 +18,7 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -162,6 +163,7 @@ class CliOptions {
      */
     Config setup() {
         return Config.builder()
+                .withPluginFile(getPluginFilePath())
                 .withPlugins(getPlugins())
                 .withPluginDir(getPluginDir())
                 .withCleanPluginsDir(isCleanPluginDir())
@@ -209,6 +211,14 @@ class CliOptions {
             }
         }
         return pluginFile;
+    }
+    private Path getPluginFilePath() {
+        File pluginFile = getPluginFile();
+        if (pluginFile != null) {
+            return pluginFile.toPath();
+        } else {
+            return null;
+        }
     }
 
     /**

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Config.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Config.java
@@ -22,6 +22,7 @@ import java.util.List;
  * Defaults for update centers will be set for you
  */
 public class Config {
+    private final Path pluginFilePath;
     private final File pluginDir;
     private final boolean cleanPluginDir;
     private final boolean showWarnings;
@@ -58,6 +59,7 @@ public class Config {
     private final LogOutput logOutput;
 
     private Config(
+            Path pluginFilePath,
             File pluginDir,
             boolean cleanPluginDir,
             boolean showWarnings,
@@ -81,6 +83,7 @@ public class Config {
             List<Credentials> credentials,
             Path cachePath,
             boolean hideWarnings) {
+        this.pluginFilePath = pluginFilePath;
         this.pluginDir = pluginDir;
         this.cleanPluginDir = cleanPluginDir;
         this.showWarnings = showWarnings;
@@ -107,6 +110,9 @@ public class Config {
         this.hideWarnings = hideWarnings;
     }
 
+    public Path getPluginFilePath(){
+        return pluginFilePath;
+    }
     public File getPluginDir() {
         return pluginDir;
     }
@@ -214,6 +220,7 @@ public class Config {
     }
 
     public static class Builder {
+        private Path pluginFilePath;
         private File pluginDir;
         private boolean cleanPluginDir;
         private boolean showWarnings;
@@ -241,6 +248,10 @@ public class Config {
         private Builder() {
         }
 
+        public Builder withPluginFile(Path pluginFilePath) {
+            this.pluginFilePath = pluginFilePath;
+            return this;
+        }
         public Builder withPluginDir(File pluginDir) {
             this.pluginDir = pluginDir;
             return this;
@@ -370,6 +381,7 @@ public class Config {
 
         public Config build() {
             return new Config(
+                    pluginFilePath,
                     pluginDir,
                     cleanPluginDir,
                     showWarnings,

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/FileType.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/FileType.java
@@ -1,0 +1,7 @@
+package io.jenkins.tools.pluginmanager.impl;
+
+public enum FileType {
+    TXT,
+    YAML,
+    UNKNOWN
+}

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -14,14 +14,17 @@ import io.jenkins.tools.pluginmanager.parsers.TxtOutputConverter;
 import io.jenkins.tools.pluginmanager.parsers.YamlPluginOutputConverter;
 import io.jenkins.tools.pluginmanager.util.FileDownloadResponseHandler;
 import io.jenkins.tools.pluginmanager.util.ManifestTools;
+import java.io.BufferedWriter;
 import java.io.Closeable;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -90,6 +93,9 @@ import static io.jenkins.tools.pluginmanager.util.PluginManagerUtils.removePossi
 public class PluginManager implements Closeable {
     private static final VersionNumber LATEST = new VersionNumber(Plugin.LATEST);
     private final List<Plugin> failedPlugins;
+    private final Path pluginFilePath;
+    private File pluginLockFile;
+
     /**
      * Directory where the plugins will be downloaded
      */
@@ -126,6 +132,7 @@ public class PluginManager implements Closeable {
     public PluginManager(Config cfg) {
         this.cfg = cfg;
         logOutput = cfg.getLogOutput();
+        pluginFilePath = cfg.getPluginFilePath();
         pluginDir = cfg.getPluginDir();
         jenkinsVersion = cfg.getJenkinsVersion();
         final String warArg = cfg.getJenkinsWar();
@@ -198,6 +205,7 @@ public class PluginManager implements Closeable {
      * @since TODO
      */
     public void start(boolean downloadUc) {
+        createPluginLockFile();
         if (cfg.isCleanPluginDir() && pluginDir.exists()) {
             try {
                 logVerbose("Cleaning up the target plugin directory: " + pluginDir);
@@ -234,6 +242,8 @@ public class PluginManager implements Closeable {
         effectivePlugins = findEffectivePlugins(pluginsToBeDownloaded);
 
         listPlugins();
+        // Writing to plugin lock file
+        writeToPluginLockFile(allPluginsAndDependencies);
         showSpecificSecurityWarnings(pluginsToBeDownloaded);
         checkVersionCompatibility(jenkinsVersion, pluginsToBeDownloaded, exceptions);
         if (!exceptions.isEmpty()) {
@@ -243,6 +253,31 @@ public class PluginManager implements Closeable {
             downloadPlugins(pluginsToBeDownloaded);
         }
         logMessage("Done");
+    }
+
+    void createPluginLockFile() {
+        if (pluginFilePath != null) {
+            Path pluginLockFilePath = pluginFilePath.resolveSibling("plugins-lock.txt");
+            pluginLockFile = pluginLockFilePath.toFile();
+
+            try {
+                if (!pluginLockFile.exists()) {
+                    boolean created = pluginLockFile.createNewFile();
+                    if (created) {
+                        logVerbose("Plugin lock file created successfully: " + pluginLockFile.getAbsolutePath());
+                    } else {
+                        logVerbose("Plugin lock file already exists: " + pluginLockFile.getAbsolutePath());
+                    }
+                } else {
+                    logVerbose("Plugin lock file already exists: " + pluginLockFile.getAbsolutePath());
+                }
+            } catch (IOException e) {
+                logVerbose("Error creating plugin lock file: " + e.getMessage());
+                e.printStackTrace();
+            }
+        } else {
+            logVerbose("Error: pluginFilePath is null. Cannot create plugin lock file.");
+        }
     }
 
     void createPluginDir(boolean failIfExists) {
@@ -331,6 +366,31 @@ public class PluginManager implements Closeable {
                     .isOlderThan(installedEntry.getValue().getVersion())) {
                 effectivePlugins.replace(installedEntry.getKey(), installedEntry.getValue());
             }
+        }
+    }
+
+    /**
+     * Writes the plugins and their versions to a plugin-lock.txt file.
+     *
+     * @param allPluginsAndDependencies List of plugins that will be downloaded.
+     */
+    public void writeToPluginLockFile(Map<String,Plugin> allPluginsAndDependencies) {
+        if (pluginLockFile != null) {
+            try (BufferedWriter writer = new BufferedWriter(new FileWriter(pluginLockFile,StandardCharsets.UTF_8))) {
+                for (Map.Entry<String, Plugin> entry : allPluginsAndDependencies.entrySet()) {
+                    Plugin plugin = entry.getValue();
+                    String pluginLine = String.format("%s:%s", plugin.getName(), plugin.getVersion());
+                    writer.write(pluginLine);
+                    writer.newLine();
+                }
+                logVerbose("Plugin lock file (" + pluginLockFile + ") has been successfully created.");
+            } catch (UnsupportedEncodingException e) {
+                e.printStackTrace();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        } else {
+            System.err.println("pluginLockFile is null");
         }
     }
 


### PR DESCRIPTION
fixes #488 
```plugins-lock.txt``` or ```plugins-lock.yaml``` file is the full list of plugins generated at a point in time with a specific Jenkins version and includes the plugins declared by the user and all the dependencies of those plugins.

```plugins-lock.txt``` or ```plugins-lock.yaml``` file describe all the plugins and versions that were read from the Jenkins update center at the time the command was executed.

A ```plugins-lock.txt``` or ```plugins-lock.yaml``` file is created on the same directory as the ```plugins.txt``` or ```plugins.yaml```, in which plugins were listed to be downloaded and the listed plugins as well their dependencies are written in the lock file.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes

