### PR TITLE
Fix findPluginsToDownload falsely check installed version

### DIFF
--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -278,16 +278,16 @@ public class PluginManager implements Closeable {
             String pluginName = requestedPlugin.getKey();
             Plugin plugin = requestedPlugin.getValue();
             VersionNumber installedVersion = null;
-            if (installedPluginVersions.containsKey(pluginName)) {
-                installedVersion = installedPluginVersions.get(pluginName).getVersion();
-            } else if (bundledPluginVersions.containsKey(pluginName)) {
-                installedVersion = bundledPluginVersions.get(pluginName).getVersion();
-            } else if (bundledPluginVersions.containsKey(pluginName) &&
+            if (bundledPluginVersions.containsKey(pluginName) &&
                     installedPluginVersions.containsKey(pluginName)) {
                 installedVersion = bundledPluginVersions.get(pluginName).getVersion().
                         isNewerThan(installedPluginVersions.get(pluginName).getVersion()) ?
                         bundledPluginVersions.get(pluginName).getVersion() :
                         installedPluginVersions.get(pluginName).getVersion();
+            } else if (installedPluginVersions.containsKey(pluginName)) {
+                installedVersion = installedPluginVersions.get(pluginName).getVersion();
+            } else if (bundledPluginVersions.containsKey(pluginName)) {
+                installedVersion = bundledPluginVersions.get(pluginName).getVersion();
             }
             if (installedVersion == null) {
                 logVerbose(String.format(

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
@@ -866,8 +866,10 @@ public class PluginManagerTest {
 
         installedPlugins.put("git", new Plugin("git", "1.1.1", null, null));
         installedPlugins.put("git-client", new Plugin("git-client","2.7.5", null, null));
+        installedPlugins.put("ssh-credentials", new Plugin("structs", "1.12", null, null));
 
         bundledPlugins.put("structs", new Plugin("structs", "1.16", null, null));
+        bundledPlugins.put("ssh-credentials", new Plugin("structs", "1.14", null, null));
 
         pm.setInstalledPluginVersions(installedPlugins);
         pm.setBundledPluginVersions(bundledPlugins);
@@ -877,8 +879,7 @@ public class PluginManagerTest {
         assertThat(actualPlugins)
                 .containsExactlyInAnyOrder(
                         new Plugin("credentials", "2.1.14", null, null),
-                        new Plugin("structs", "1.18", null, null),
-                        new Plugin("ssh-credentials", "1.13", null, null));
+                        new Plugin("structs", "1.18", null, null));
     }
 
     @Test


### PR DESCRIPTION
I noticed that `PluginManager#findPluginsToDownload` has a wrong logic if-else. For a requested plugin, if there is both installed plugin and bundled plugin, then the method only gets the version from the installed one without checking if the bundled one is newer. The else logic was added in c445deaa4ce961104f63995cf6c1ada59929e6ac

### Testing done
I have adjusted the test case to suit the new changes.

### Submitter checklist

```[tasklist]
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

