### PR TITLE
Add SHA256 checksum to GitHub release

### DIFF
--- a/.github/workflows/publish-release-artifact.yml
+++ b/.github/workflows/publish-release-artifact.yml
@@ -29,7 +29,7 @@ jobs:
           PROJECT_VERSION=${{ steps.set-version.outputs.project-version }}
           echo $PROJECT_VERSION
           echo "file-name=$FILE_NAME" >> $GITHUB_OUTPUT
-          SHA256SUM=$(curl -fsSL https://repo.jenkins-ci.org/api/storage/releases/$GROUP_ID/$ARTIFACT_ID/$PROJECT_VERSION/$ARTIFACT_ID-$PROJECT_VERSION.jar | jq -r .checksums.sha256)
+          SHA256SUM=$(curl -fsSL https://repo.jenkins-ci.org/api/storage/releases/$GROUP_ID/$ARTIFACT_ID/$PROJECT_VERSION/$ARTIFACT_ID-$PROJECT_VERSION.jar.sha256)
           echo "${SHA256SUM}  $FILE_NAME-$PROJECT_VERSION.jar" >$FILE_NAME-$PROJECT_VERSION.jar.sha256
           wget -q https://repo.jenkins-ci.org/releases/$GROUP_ID/$ARTIFACT_ID/$PROJECT_VERSION/$ARTIFACT_ID-$PROJECT_VERSION.jar \
             -O $FILE_NAME-$PROJECT_VERSION.jar \

--- a/.github/workflows/publish-release-artifact.yml
+++ b/.github/workflows/publish-release-artifact.yml
@@ -29,10 +29,17 @@ jobs:
           PROJECT_VERSION=${{ steps.set-version.outputs.project-version }}
           echo $PROJECT_VERSION
           echo "file-name=$FILE_NAME" >> $GITHUB_OUTPUT
+          SHA256SUM=$(curl -fsSL https://repo.jenkins-ci.org/api/storage/releases/$GROUP_ID/$ARTIFACT_ID/$PROJECT_VERSION/$ARTIFACT_ID-$PROJECT_VERSION.jar | jq -r .checksums.sha256)
+          echo "${SHA256SUM}  $FILE_NAME-$PROJECT_VERSION.jar" >$FILE_NAME-$PROJECT_VERSION.jar.sha256
           wget -q https://repo.jenkins-ci.org/releases/$GROUP_ID/$ARTIFACT_ID/$PROJECT_VERSION/$ARTIFACT_ID-$PROJECT_VERSION.jar \
-            -O $FILE_NAME-$PROJECT_VERSION.jar
+            -O $FILE_NAME-$PROJECT_VERSION.jar \
+            && sha256sum -c --strict $FILE_NAME-$PROJECT_VERSION.jar.sha256
       - name: Upload Release Asset
         id: upload-release-asset
+        uses: softprops/action-gh-release@9d7c94cfd0a1f3ed45544c887983e9fa900f0564
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ steps.set-version.outputs.project-version }} ./${{ steps.fetch-artifact.outputs.file-name }}-${{ steps.set-version.outputs.project-version }}.jar
+        with:
+          files: |
+            ${{ steps.fetch-artifact.outputs.file-name }}-${{ steps.set-version.outputs.project-version }}.jar
+            ${{ steps.fetch-artifact.outputs.file-name }}-${{ steps.set-version.outputs.project-version }}.jar.sha256

--- a/.github/workflows/publish-release-artifact.yml
+++ b/.github/workflows/publish-release-artifact.yml
@@ -29,7 +29,7 @@ jobs:
           PROJECT_VERSION=${{ steps.set-version.outputs.project-version }}
           echo $PROJECT_VERSION
           echo "file-name=$FILE_NAME" >> $GITHUB_OUTPUT
-          SHA256SUM=$(curl -fsSL https://repo.jenkins-ci.org/api/storage/releases/$GROUP_ID/$ARTIFACT_ID/$PROJECT_VERSION/$ARTIFACT_ID-$PROJECT_VERSION.jar.sha256)
+          SHA256SUM=$(curl -fsSL https://repo.jenkins-ci.org/releases/$GROUP_ID/$ARTIFACT_ID/$PROJECT_VERSION/$ARTIFACT_ID-$PROJECT_VERSION.jar.sha256)
           echo "${SHA256SUM}  $FILE_NAME-$PROJECT_VERSION.jar" >$FILE_NAME-$PROJECT_VERSION.jar.sha256
           wget -q https://repo.jenkins-ci.org/releases/$GROUP_ID/$ARTIFACT_ID/$PROJECT_VERSION/$ARTIFACT_ID-$PROJECT_VERSION.jar \
             -O $FILE_NAME-$PROJECT_VERSION.jar \


### PR DESCRIPTION
- Verify the SHA256 checksum when downloading from Artifactory
- Publish the SHA256 checksum to GitHub releases so that consumers who download it from there may also verify

### Testing done

Tested the changes to `fetch-artifact` end-to-end in GitHub Actions.

Did not test the changes to `upload-release-asset`, but those match our usage in Jenkins core and should be easy to debug in case of any issues the next time we perform a release.