### PR TITLE
Remove explicit snakeyaml dependency

### DIFF
--- a/plugin-management-library/pom.xml
+++ b/plugin-management-library/pom.xml
@@ -65,12 +65,6 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>2.17.1</version>
         </dependency>
-        <!-- TODO: Remove when jackson dataformat snakeyaml dependency is at least 1.32 -->
-        <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>2.2</version>
-        </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>


### PR DESCRIPTION
## Remove explicit snakeyaml dependency

Rely on the transitive dependency from the Jackson dataformat library.

Commit 6239603091be6af55c9459bb2baa1a272fa216a9 added the dependency in order to assure that we were including the most recent release of the snakeyaml jar file.  The Jackson dataformat library version that we are using already depends on the most recent snakeyaml release, so we no longer need this explicit dependency.

Reverts 6239603091be6af55c9459bb2baa1a272fa216a9

### Testing done

Confirmed that automated tests pass

Confirmed that the snakeyaml included in the plugin installation manager jar file after this change is the same as the snakeyaml included in the most recent release.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
