### PR TITLE
Add support for custom Jenkins archive repository mirror URL

### DIFF
--- a/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/CliOptions.java
+++ b/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/CliOptions.java
@@ -115,6 +115,13 @@ class CliOptions {
             handler = URLOptionHandler.class)
     private URL jenkinsIncrementalsRepoMirror;
 
+    @Option(name = "--jenkins-archive-repo-mirror",
+            usage = "Set the custom URL for the Jenkins plugin archive repository, will override " +
+                    "the JENKINS_ARCHIVE_REPO_MIRROR environment variable. If not set via CLI option or " +
+                    "environment variable, will default to " + Settings.DEFAULT_ARCHIVE_REPO_MIRROR_LOCATION,
+            handler = URLOptionHandler.class)
+    private URL jenkinsArchiveRepoMirror;
+
     @Option(name = "--jenkins-plugin-info",
             usage = "Sets the location of plugin information; will override JENKINS_PLUGIN_INFO environment variable. " +
                     "If not set via CLI option or environment variable, will default to " +
@@ -168,6 +175,7 @@ class CliOptions {
                 .withJenkinsUc(getUpdateCenter())
                 .withJenkinsUcExperimental(getExperimentalUpdateCenter())
                 .withJenkinsIncrementalsRepoMirror(getIncrementalsMirror())
+                .withJenkinsArchiveRepoMirror(getArchiveMirror())
                 .withJenkinsPluginInfo(getPluginInfo())
                 .withJenkinsVersion(getJenkinsVersion())
                 .withJenkinsWar(getJenkinsWar())
@@ -442,6 +450,34 @@ class CliOptions {
                     jenkinsIncrementalsRepo);
         }
         return jenkinsIncrementalsRepo;
+    }
+
+    /**
+     * Determines the archive repository mirror URL. If a value is set via CLI option, it will override a
+     * value set via environment variable. If neither are set, the default in the Settings class will be used.
+     *
+     * @return the archive repository mirror URL
+     */
+    private URL getArchiveMirror() {
+        URL archiveRepoMirror;
+        String archiveRepoEnv = System.getenv("JENKINS_ARCHIVE_REPO_MIRROR");
+        if (jenkinsArchiveRepoMirror != null) {
+            archiveRepoMirror = jenkinsArchiveRepoMirror;
+            logVerbose("Using archive repository mirror " + archiveRepoMirror + " specified with CLI option");
+        } else if (!StringUtils.isEmpty(archiveRepoEnv)) {
+            try {
+                archiveRepoMirror = new URL(archiveRepoEnv);
+            } catch (MalformedURLException e) {
+                throw new RuntimeException(e);
+            }
+            logVerbose("Using archive repository mirror " + archiveRepoMirror +
+                    " from JENKINS_ARCHIVE_REPO_MIRROR environment variable");
+        } else {
+            archiveRepoMirror = Settings.DEFAULT_ARCHIVE_REPO_MIRROR;
+            logVerbose("No CLI option or environment variable set for archive repository mirror, using default of " +
+                    archiveRepoMirror);
+        }
+        return archiveRepoMirror;
     }
 
     /**

--- a/plugin-management-cli/src/test/java/io/jenkins/tools/pluginmanager/cli/CliOptionsTest.java
+++ b/plugin-management-cli/src/test/java/io/jenkins/tools/pluginmanager/cli/CliOptionsTest.java
@@ -32,7 +32,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
-
 public class CliOptionsTest {
     private CliOptions options;
     private CmdLineParser parser;
@@ -197,16 +196,19 @@ public class CliOptionsTest {
         String ucEnvVar = "https://updates.jenkins.io/env";
         String experimentalUcEnvVar = "https://updates.jenkins.io/experimental/env";
         String incrementalsEnvVar = "https://repo.jenkins-ci.org/incrementals/env";
+        String archiveEnvVar = "https://mirrors.jenkins-ci.org/archive/env";
         String pluginInfoEnvVar = "https://updates.jenkins.io/current/plugin-versions/env";
 
         String ucCli = "https://updates.jenkins.io/cli";
         String experiementalCli = "https://updates.jenkins.io/experimental/cli";
         String incrementalsCli = "https://repo.jenkins-ci.org/incrementals/cli";
+        String archiveCli = "https://mirrors.jenkins-ci.org/archive/cli";
         String pluginInfoCli = "https://updates.jenkins.io/current/plugin-versions/cli";
 
         parser.parseArgument("--jenkins-update-center", ucCli,
                 "--jenkins-experimental-update-center", experiementalCli,
                 "--jenkins-incrementals-repo-mirror", incrementalsCli,
+                "--jenkins-archive-repo-mirror", archiveCli,
                 "--jenkins-plugin-info", pluginInfoCli);
 
         Config cfg = options.setup();
@@ -214,6 +216,7 @@ public class CliOptionsTest {
         assertThat(cfg.getJenkinsUc()).hasToString(ucCli + "/update-center.json");
         assertThat(cfg.getJenkinsUcExperimental()).hasToString(experiementalCli + "/update-center.json");
         assertThat(cfg.getJenkinsIncrementalsRepoMirror()).hasToString(incrementalsCli);
+        assertThat(cfg.getJenkinsArchiveRepoMirror()).hasToString(archiveCli);
         assertThat(cfg.getJenkinsPluginInfo()).hasToString(pluginInfoCli);
     }
 

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Config.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Config.java
@@ -46,6 +46,7 @@ public class Config {
     private final URL jenkinsUc;
     private final URL jenkinsUcExperimental;
     private final URL jenkinsIncrementalsRepoMirror;
+    private final URL jenkinsArchiveRepoMirror;
     private final URL jenkinsPluginInfo;
     private final boolean doDownload;
     private final boolean useLatestSpecified;
@@ -71,6 +72,7 @@ public class Config {
             URL jenkinsUc,
             URL jenkinsUcExperimental,
             URL jenkinsIncrementalsRepoMirror,
+            URL jenkinsArchiveRepoMirror,
             URL jenkinsPluginInfo,
             boolean doDownload,
             boolean useLatestSpecified,
@@ -94,6 +96,7 @@ public class Config {
         this.jenkinsUc = jenkinsUc;
         this.jenkinsUcExperimental = jenkinsUcExperimental;
         this.jenkinsIncrementalsRepoMirror = jenkinsIncrementalsRepoMirror;
+        this.jenkinsArchiveRepoMirror = jenkinsArchiveRepoMirror;
         this.jenkinsPluginInfo = jenkinsPluginInfo;
         this.doDownload = doDownload;
         this.useLatestSpecified = useLatestSpecified;
@@ -158,6 +161,10 @@ public class Config {
 
     public URL getJenkinsIncrementalsRepoMirror() {
         return jenkinsIncrementalsRepoMirror;
+    }
+
+    public URL getJenkinsArchiveRepoMirror() {
+        return jenkinsArchiveRepoMirror;
     }
 
     public URL getJenkinsPluginInfo() {
@@ -228,6 +235,7 @@ public class Config {
         private URL jenkinsUc = Settings.DEFAULT_UPDATE_CENTER;
         private URL jenkinsUcExperimental = Settings.DEFAULT_EXPERIMENTAL_UPDATE_CENTER;
         private URL jenkinsIncrementalsRepoMirror = Settings.DEFAULT_INCREMENTALS_REPO_MIRROR;
+        private URL jenkinsArchiveRepoMirror = Settings.DEFAULT_ARCHIVE_REPO_MIRROR;
         private URL jenkinsPluginInfo = Settings.DEFAULT_PLUGIN_INFO;
         private boolean doDownload;
         private boolean useLatestSpecified;
@@ -317,6 +325,11 @@ public class Config {
             return this;
         }
 
+        public Builder withJenkinsArchiveRepoMirror(URL jenkinsArchiveRepoMirror) {
+            this.jenkinsArchiveRepoMirror = jenkinsArchiveRepoMirror;
+            return this;
+        }
+
         public Builder withJenkinsPluginInfo(URL jenkinsPluginInfo) {
             this.jenkinsPluginInfo = jenkinsPluginInfo;
             return this;
@@ -383,6 +396,7 @@ public class Config {
                     jenkinsUc,
                     jenkinsUcExperimental,
                     jenkinsIncrementalsRepoMirror,
+                    jenkinsArchiveRepoMirror,
                     jenkinsPluginInfo,
                     doDownload,
                     useLatestSpecified,

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Settings.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Settings.java
@@ -19,6 +19,8 @@ public class Settings {
     public static final String DEFAULT_EXPERIMENTAL_UPDATE_CENTER_LOCATION = "https://updates.jenkins.io/experimental" + DEFAULT_UPDATE_CENTER_FILENAME;
     public static final URL DEFAULT_INCREMENTALS_REPO_MIRROR;
     public static final String DEFAULT_INCREMENTALS_REPO_MIRROR_LOCATION = "https://repo.jenkins-ci.org/incrementals";
+    public static final URL DEFAULT_ARCHIVE_REPO_MIRROR;
+    public static final String DEFAULT_ARCHIVE_REPO_MIRROR_LOCATION = "https://archives.jenkins.io/";
     public static final URL DEFAULT_PLUGIN_INFO;
     public static final String DEFAULT_PLUGIN_INFO_LOCATION = "https://updates.jenkins.io/plugin-versions.json";
     public static final Path DEFAULT_CACHE_PATH;
@@ -45,6 +47,7 @@ public class Settings {
             DEFAULT_UPDATE_CENTER = new URL(DEFAULT_UPDATE_CENTER_LOCATION);
             DEFAULT_EXPERIMENTAL_UPDATE_CENTER = new URL(DEFAULT_EXPERIMENTAL_UPDATE_CENTER_LOCATION);
             DEFAULT_INCREMENTALS_REPO_MIRROR = new URL(DEFAULT_INCREMENTALS_REPO_MIRROR_LOCATION);
+            DEFAULT_ARCHIVE_REPO_MIRROR = new URL(DEFAULT_ARCHIVE_REPO_MIRROR_LOCATION);
             DEFAULT_PLUGIN_INFO = new URL(DEFAULT_PLUGIN_INFO_LOCATION);
         } catch (MalformedURLException e) {
             /* Spotbugs 4.7.0 warns when throwing a runtime exception,

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -120,7 +120,6 @@ public class PluginManager implements Closeable {
     private final LogOutput logOutput;
 
     private static final int DEFAULT_MAX_RETRIES = 3;
-    private static final String MIRROR_FALLBACK_BASE_URL = "https://archives.jenkins.io/";
 
     @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "we want the user to be able to specify a path")
     public PluginManager(Config cfg) {
@@ -1305,10 +1304,10 @@ public class PluginManager implements Closeable {
         if(urlString.startsWith("http://") || urlString.startsWith("https://")){
             success = downloadHttpToFile(urlString, plugin, pluginFile, maxRetries);
 
-            if (!success && !urlString.startsWith(MIRROR_FALLBACK_BASE_URL)) {
-                logMessage("Downloading from mirrors failed, falling back to " + MIRROR_FALLBACK_BASE_URL);
+            if (!success && !urlString.startsWith(cfg.getJenkinsArchiveRepoMirror().toString())) {
+                logMessage("Downloading from mirrors failed, falling back to " + cfg.getJenkinsArchiveRepoMirror().toString());
                 // as fallback try to directly download from Jenkins server (only if mirrors fail)
-                urlString = appendPathOntoUrl(MIRROR_FALLBACK_BASE_URL, "/plugins", plugin.getName(), plugin.getVersion(), plugin.getName() + ".hpi");
+                urlString = appendPathOntoUrl(cfg.getJenkinsArchiveRepoMirror().toString(), "/plugins", plugin.getName(), plugin.getVersion(), plugin.getName() + ".hpi");
                 return downloadToFile(urlString, plugin, fileLocation, 1);
             }
         } else if (urlString.startsWith("file://")){

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/config/ConfigArchiveRepoTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/config/ConfigArchiveRepoTest.java
@@ -1,0 +1,26 @@
+package io.jenkins.tools.pluginmanager.config;
+
+import java.net.URL;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ConfigArchiveRepoTest {
+
+    @Test
+    public void testDefaultArchiveRepoMirror() {
+        // default archive url
+        Config config = Config.builder().build();
+        assertEquals(Settings.DEFAULT_ARCHIVE_REPO_MIRROR, config.getJenkinsArchiveRepoMirror());
+    }
+
+    @Test
+    public void testSetCustomArchiveRepoMirror() throws Exception {
+        // custom archive url
+        URL customUrl = new URL("https://mirrors.jenkins-ci.org/");
+        Config config = Config.builder()
+                .withJenkinsArchiveRepoMirror(customUrl)
+                .build();
+        assertEquals(customUrl, config.getJenkinsArchiveRepoMirror());
+    }
+}


### PR DESCRIPTION
### Description

This PR introduces the ability to set a custom URL for the Jenkins plugin archive repository. The functionality is implemented through a new command-line option `--jenkins-archive-repo-mirror` and the corresponding environment variable `JENKINS_ARCHIVE_REPO_MIRROR`.
This allows users to specify an alternative archive repository mirror, making it easier to work with repository mirrors, especially in environments with proxies like `Sonatype Nexus Repository`.

If no custom URL is provided, the default value` https://archives.jenkins.io/` will be used.
This ensures backward compatibility and seamless usage.

### Changes

**CliOptions.java**:
Added the `--jenkins-archive-repo-mirror` CLI option to allow specifying a custom archive repository mirror URL.

**Config.java**:
Added support for storing and retrieving the custom archive repository mirror URL.

**Settings.java**:
Introduced a default URL constant for the archive repository mirror.

**PluginManager.java**:
Updated to use the custom archive repository URL if specified, falling back to the default if not.

**Tests**:
Added tests in `ConfigArchiveRepoTest.java` to verify correct behavior for both default and custom archive repository URLs.

### Testing done

**Command-line option tests**:
Updated `ConfigArchiveRepoTest.java` to test the new `--jenkins-archive-repo-mirror` CLI option.

**Environment variable tests**:
Environment variable tests for `JENKINS_ARCHIVE_REPO_MIRROR` are not yet implemented but can be added if necessary.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
