### PR TITLE
Add --jenkins-update-center-download-url CLI option (fixes #889)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ exit
 * `--jenkins-experimental-update-center`: (optional) Sets the experimental update center, which can also be set via the JENKINS_UC_EXPERIMENTAL environment variable. If a CLI option is entered, it will override what is set in the environment variable. If not set via CLI option or environment variable, will default to https://updates.jenkins.io/experimental/update-center.actual.json
 * `--jenkins-incrementals-repo-mirror`: (optional) Sets the incrementals repository mirror, which can also be set via the JENKINS_INCREMENTALS_REPO_MIRROR environment variable. If a CLI option is entered, it will override what is set in the environment variable. If not set via CLI option or environment variable, will default to https://repo.jenkins-ci.org/incrementals.
 * `--jenkins-plugin-info`: (optional) Sets the location of plugin information, which can also be set via the JENKINS_PLUGIN_INFO environment variable. If a CLI option is provided, it will override what is set in the environment variable. If not set via CLI option or environment variable, will default to https://updates.jenkins.io/current/plugin-versions.json.
+* `--jenkins-update-center-download-url`: (optional) Sets a custom plugin download URL, which can also be set via the JENKINS_UC_DOWNLOAD_URL environment variable. If a CLI option is provided, it will override what is set in the environment variable. When set, replaces the plugin download URL from `update-center.json` with this value. Often used to cache or proxy the Jenkins plugin download site.
 * `--version` or `-v`: (optional) Displays the plugin management tool version and exits.
 * `--no-download`: (optional) Do not download plugins. By default plugins will be downloaded.
 * `--skip-failed-plugins`: (optional) Adds the option to skip plugins that fail to download - CAUTION should be used when passing this flag as it could leave
@@ -78,7 +79,7 @@ if the user doesn't have a home directory when it will go to: `$(pwd)/.cache/jen
 * `JENKINS_UC_DOWNLOAD`: *DEPRECATED* use `JENKINS_UC_DOWNLOAD_URL` instead.
 
 * `JENKINS_UC_DOWNLOAD_URL`: used to configure a custom URL from where plugins will be downloaded from. When this value is set, it replaces the plugin download URL found in the `update-center.json` file with `${JENKINS_UC_DOWNLOAD_URL}`. Often used to cache or to proxy the Jenkins plugin download site.
-If set then all plugins will be downloaded through that URL.
+If set then all plugins will be downloaded through that URL. Can also be set via the `--jenkins-update-center-download-url` CLI option, which takes precedence over the environment variable.
 
 * `JENKINS_UC_HASH_FUNCTION`: used to configure the hash function which checks content from UCs. Currently `SHA1` (deprecated), `SHA256` (default), and `SHA512` can be specified.
 

--- a/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/CliOptions.java
+++ b/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/CliOptions.java
@@ -125,6 +125,13 @@ class CliOptions {
             handler = URLOptionHandler.class)
     private URL jenkinsPluginInfo;
 
+    @Option(name = "--jenkins-update-center-download-url",
+            usage = "Sets a custom plugin download URL; will override JENKINS_UC_DOWNLOAD_URL environment variable. " +
+                    "When set, replaces the plugin download URL from update-center.json with this value. " +
+                    "If not set via CLI option or environment variable, the URL from update-center.json is used.",
+            handler = URLOptionHandler.class)
+    private URL jenkinsUcDownloadUrl;
+
     @Option(name = "--version", aliases = {"-v"}, usage = "View version and exit", handler = BooleanOptionHandler.class)
     private boolean showVersion;
 
@@ -172,6 +179,7 @@ class CliOptions {
                 .withJenkinsUcExperimental(getExperimentalUpdateCenter())
                 .withJenkinsIncrementalsRepoMirror(getIncrementalsMirror())
                 .withJenkinsPluginInfo(getPluginInfo())
+                .withJenkinsUcDownloadUrl(getJenkinsUcDownloadUrl())
                 .withJenkinsVersion(getJenkinsVersion())
                 .withJenkinsWar(getJenkinsWar())
                 .withShowWarnings(isShowWarnings())
@@ -475,6 +483,36 @@ class CliOptions {
             logVerbose("No CLI option or environment variable set for plugin info, using default of " + pluginInfo);
         }
         return pluginInfo;
+    }
+
+    /**
+     * Determines the custom plugin download URL. If a value is set via CLI option, it will override a value set
+     * via the JENKINS_UC_DOWNLOAD_URL environment variable. If neither is set, returns null so the URL from
+     * update-center.json is used.
+     *
+     * @return the plugin download URL, or null if not configured
+     */
+    private URL getJenkinsUcDownloadUrl() {
+        URL downloadUrl;
+        if (jenkinsUcDownloadUrl != null) {
+            downloadUrl = jenkinsUcDownloadUrl;
+            logVerbose("Using plugin download URL " + downloadUrl + " specified with CLI option");
+        } else if (!StringUtils.isEmpty(System.getenv("JENKINS_UC_DOWNLOAD_URL"))) {
+            try {
+                downloadUrl = new URL(System.getenv("JENKINS_UC_DOWNLOAD_URL"));
+            } catch (MalformedURLException e) {
+                /* Spotbugs 4.7.0 warns when throwing a runtime exception,
+                 * but the program cannot do anything with a malformed URL.
+                 * Spotbugs warning is ignored.
+                 */
+                throw new RuntimeException(e);
+            }
+            logVerbose("Using plugin download URL " + downloadUrl + " from JENKINS_UC_DOWNLOAD_URL environment variable");
+        } else {
+            downloadUrl = null;
+            logVerbose("No CLI option or environment variable set for plugin download URL, using URLs from update-center.json");
+        }
+        return downloadUrl;
     }
 
     /**

--- a/plugin-management-cli/src/test/java/io/jenkins/tools/pluginmanager/cli/CliOptionsTest.java
+++ b/plugin-management-cli/src/test/java/io/jenkins/tools/pluginmanager/cli/CliOptionsTest.java
@@ -78,7 +78,19 @@ class CliOptionsTest {
         assertThat(cfg.getJenkinsUcExperimental()).hasToString(Settings.DEFAULT_EXPERIMENTAL_UPDATE_CENTER_LOCATION);
         assertThat(cfg.getJenkinsIncrementalsRepoMirror()).hasToString(Settings.DEFAULT_INCREMENTALS_REPO_MIRROR_LOCATION);
         assertThat(cfg.getJenkinsPluginInfo()).hasToString(Settings.DEFAULT_PLUGIN_INFO_LOCATION);
+        assertThat(cfg.getJenkinsUcDownloadUrl()).isNull();
         assertThat(cfg.getHashFunction()).isEqualTo(Settings.DEFAULT_HASH_FUNCTION);
+    }
+
+    @Test
+    void setupUpdateCenterDownloadUrlCliTest() throws Exception {
+        String downloadUrlCli = "https://private-mirror.com/jenkins-updated-center/download/plugins";
+
+        parser.parseArgument("--jenkins-update-center-download-url", downloadUrlCli);
+
+        Config cfg = options.setup();
+
+        assertThat(cfg.getJenkinsUcDownloadUrl()).hasToString(downloadUrlCli);
     }
 
     @Test

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Config.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Config.java
@@ -47,6 +47,8 @@ public class Config {
     private final URL jenkinsUcExperimental;
     private final URL jenkinsIncrementalsRepoMirror;
     private final URL jenkinsPluginInfo;
+    @CheckForNull
+    private final URL jenkinsUcDownloadUrl;
     private final boolean doDownload;
     private final boolean useLatestSpecified;
     private final boolean useLatestAll;
@@ -72,6 +74,7 @@ public class Config {
             URL jenkinsUcExperimental,
             URL jenkinsIncrementalsRepoMirror,
             URL jenkinsPluginInfo,
+            URL jenkinsUcDownloadUrl,
             boolean doDownload,
             boolean useLatestSpecified,
             boolean useLatestAll,
@@ -95,6 +98,7 @@ public class Config {
         this.jenkinsUcExperimental = jenkinsUcExperimental;
         this.jenkinsIncrementalsRepoMirror = jenkinsIncrementalsRepoMirror;
         this.jenkinsPluginInfo = jenkinsPluginInfo;
+        this.jenkinsUcDownloadUrl = jenkinsUcDownloadUrl;
         this.doDownload = doDownload;
         this.useLatestSpecified = useLatestSpecified;
         this.useLatestAll = useLatestAll;
@@ -164,6 +168,11 @@ public class Config {
         return jenkinsPluginInfo;
     }
 
+    @CheckForNull
+    public URL getJenkinsUcDownloadUrl() {
+        return jenkinsUcDownloadUrl;
+    }
+
     /**
      * Get Jenkins version to be used by the plugin manager.
      * @return Jenkins version.
@@ -229,6 +238,7 @@ public class Config {
         private URL jenkinsUcExperimental = Settings.DEFAULT_EXPERIMENTAL_UPDATE_CENTER;
         private URL jenkinsIncrementalsRepoMirror = Settings.DEFAULT_INCREMENTALS_REPO_MIRROR;
         private URL jenkinsPluginInfo = Settings.DEFAULT_PLUGIN_INFO;
+        private URL jenkinsUcDownloadUrl;
         private boolean doDownload;
         private boolean useLatestSpecified;
         private boolean useLatestAll;
@@ -322,6 +332,11 @@ public class Config {
             return this;
         }
 
+        public Builder withJenkinsUcDownloadUrl(@CheckForNull URL jenkinsUcDownloadUrl) {
+            this.jenkinsUcDownloadUrl = jenkinsUcDownloadUrl;
+            return this;
+        }
+
         public Builder withDoDownload(boolean doDownload) {
             this.doDownload = doDownload;
             return this;
@@ -384,6 +399,7 @@ public class Config {
                     jenkinsUcExperimental,
                     jenkinsIncrementalsRepoMirror,
                     jenkinsPluginInfo,
+                    jenkinsUcDownloadUrl,
                     doDownload,
                     useLatestSpecified,
                     useLatestAll,

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -1241,11 +1241,11 @@ public class PluginManager implements Closeable {
         }
 
         String jenkinsUcDownload = System.getenv("JENKINS_UC_DOWNLOAD");
-        String jenkinsUcDownloadUrl = System.getenv("JENKINS_UC_DOWNLOAD_URL");
+        URL jenkinsUcDownloadUrl = cfg.getJenkinsUcDownloadUrl();
 
         if (StringUtils.isNotEmpty(pluginUrl)) {
             urlString = pluginUrl;
-        } else if (StringUtils.isNotEmpty(jenkinsUcDownloadUrl)) {
+        } else if (jenkinsUcDownloadUrl != null) {
             urlString = appendPathOntoUrl(jenkinsUcDownloadUrl, pluginName, pluginVersion, pluginName + ".hpi");
         } else if (pluginVersion.equals(Plugin.LATEST) && !StringUtils.isEmpty(jenkinsUcLatest)) {
             urlString = appendPathOntoUrl(dirName(jenkinsUcLatest), "/latest", pluginName + ".hpi");

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
@@ -20,7 +20,6 @@ import org.apache.commons.io.FilenameUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -1340,7 +1339,6 @@ class PluginManagerTest {
     /**
      * Test configuring custom update center mirror configuration (i.e. Artifactory).
      */
-    @Disabled("setting environment variables is not supported in Java 17")
     @Test
     void getDownloadPluginUrlCustomUcUrls() throws IOException {
         Config config = Config.builder()
@@ -1350,9 +1348,8 @@ class PluginManagerTest {
                 .withJenkinsUcExperimental(new URL("https://private-mirror.com/jenkins-updated-center/experimental/update-center.actual.json"))
                 .withJenkinsIncrementalsRepoMirror(new URL("https://private-mirror.com/jenkins-updated-center/incrementals"))
                 .withJenkinsPluginInfo(new URL("https://private-mirror.com/jenkins-updated-center/current/plugin-versions.json"))
+                .withJenkinsUcDownloadUrl(new URL("https://private-mirror.com/jenkins-updated-center/download/plugins"))
                 .build();
-
-        //environmentVariables.set("JENKINS_UC_DOWNLOAD_URL", "https://private-mirror.com/jenkins-updated-center/download/plugins");
 
         PluginManager pluginManager = new PluginManager(config);
 
@@ -1414,10 +1411,10 @@ class PluginManagerTest {
                             .isEqualTo("https://private-mirror.com/jenkins-updated-center/download/plugins/pluginName/1.0.0/pluginName.hpi");
                 },
                 () -> {
-                    // explicit url
+                    // explicit per-plugin URL is preserved
                     Plugin plugin = new Plugin("pluginName", "1.0.0", "https://other-mirror.com/plugins/custom-url.hpi", null);
                     assertThat(pluginManager.getPluginDownloadUrl(plugin))
-                            .isEqualTo("https://private-mirror.com/jenkins-updated-center/download/plugins/pluginName/1.0.0/pluginName.hpi");
+                            .isEqualTo("https://other-mirror.com/plugins/custom-url.hpi");
                 }
         );
     }


### PR DESCRIPTION
Adds a `--jenkins-update-center-download-url` CLI option. Previously the only way to set this was via the `JENKINS_UC_DOWNLOAD_URL` env var. Same pattern as `JENKINS_UC`, `JENKINS_UC_EXPERIMENTAL`, and the credentials env var added in #875 — CLI option wins when both are set.

While doing this I moved the env-var read out of `PluginManager.getPluginDownloadUrl()` and up into `CliOptions`, so the library is config-driven like everything else. Library users now pass the URL via `Config.builder().withJenkinsUcDownloadUrl(...)`.

This also let me re-enable `PluginManagerTest.getDownloadPluginUrlCustomUcUrls` — it had been `@Disabled` since env vars stopped being settable in Java 17 and so never ran. One assertion in it needed updating: it expected `JENKINS_UC_DOWNLOAD_URL` to override an explicit per-plugin URL, but the code (and the README) preserves explicit URLs.