### PR TITLE
feat: add --exclude-plugin option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ exit
 * `--plugin-file` or `-f`: (optional) Path to the plugins.txt, or plugins.yaml file, which contains a list of plugins to install. If this file does not exist, or if the file exists, but does not have a .txt or .yaml/.yml extension, then an error will be thrown.
 * `--plugin-download-directory` or `-d`: (optional) Directory in which to install plugins. This configuration can also be made via the PLUGIN_DIR environment variable. The directory will be first deleted, then recreated. If no directory configuration is provided, the defaults are C:\ProgramData\Jenkins\Reference\Plugins if the detected operating system is Microsoft Windows, or /usr/share/jenkins/ref/plugins otherwise.
 * `--plugins` or `-p`: (optional) List of plugins to install (see plugin format below), separated by a space.
+* `--exclude-plugins`: (optional) List of plugin names (artifact IDs) to exclude from installation/update, separated by a space. Excluded plugins are dropped from the download set even when they are pulled in as transitive dependencies of other requested plugins; a warning is logged in that case because dependent plugins may fail to load.
 * `--clean-download-directory`: (optional) If sets, cleans the plugin download directory before plugin installation. Otherwise the tool performs plugin download and reports compatibility issues, if any.
 * `--jenkins-version`: (optional) Version of Jenkins to be used.
   If not specified, the plugin manager will try to extract it from the WAR file or other sources.

--- a/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/CliOptions.java
+++ b/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/CliOptions.java
@@ -19,6 +19,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
@@ -52,6 +53,13 @@ class CliOptions {
     @Option(name = "--plugins", aliases = {"-p"}, usage = "List of plugins to install, separated by a space",
             handler = StringArrayOptionHandler.class)
     private String[] plugins = new String[0];
+
+    @Option(name = "--exclude-plugins",
+            usage = "List of plugin names to exclude from installation/update, separated by a space. " +
+                    "Excluded plugins are dropped from the download set even when they are transitive " +
+                    "dependencies of other requested plugins.",
+            handler = StringArrayOptionHandler.class)
+    private String[] excludePlugins = new String[0];
 
     @Option(name = "--jenkins-version", usage = "Jenkins version to be used. " +
             "If undefined, Plugin Manager will use alternative ways to retrieve the version, e.g. from WAR",
@@ -173,6 +181,7 @@ class CliOptions {
     Config setup() {
         return Config.builder()
                 .withPlugins(getPlugins())
+                .withExcludePlugins(getExcludePlugins())
                 .withPluginDir(getPluginDir())
                 .withCleanPluginsDir(isCleanPluginDir())
                 .withJenkinsUc(getUpdateCenter())
@@ -295,6 +304,13 @@ class CliOptions {
             }
         }
         return requestedPlugins;
+    }
+
+    private List<String> getExcludePlugins() {
+        if (excludePlugins == null || excludePlugins.length == 0) {
+            return Collections.emptyList();
+        }
+        return new ArrayList<>(Arrays.asList(excludePlugins));
     }
 
     /**

--- a/plugin-management-cli/src/test/java/io/jenkins/tools/pluginmanager/cli/CliOptionsTest.java
+++ b/plugin-management-cli/src/test/java/io/jenkins/tools/pluginmanager/cli/CliOptionsTest.java
@@ -348,6 +348,22 @@ class CliOptionsTest {
     }
 
     @Test
+    void excludePluginsDefaultTest() throws Exception {
+        parser.parseArgument();
+
+        Config cfg = options.setup();
+        assertThat(cfg.getExcludePlugins()).isEmpty();
+    }
+
+    @Test
+    void excludePluginsParseTest() throws Exception {
+        parser.parseArgument("--exclude-plugins", "git", "matrix-auth", "credentials");
+
+        Config cfg = options.setup();
+        assertThat(cfg.getExcludePlugins()).containsExactly("git", "matrix-auth", "credentials");
+    }
+
+    @Test
     void outputFormatTest() throws Exception {
         parser.parseArgument("--plugins", "foo", "--output", "yaml");
 

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Config.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/config/Config.java
@@ -41,6 +41,7 @@ public class Config {
     @CheckForNull
     private final String jenkinsWar;
     private final List<Plugin> plugins;
+    private final List<String> excludePlugins;
     private final boolean verbose;
     private final HashFunction hashFunction;
     private final URL jenkinsUc;
@@ -70,6 +71,7 @@ public class Config {
             VersionNumber jenkinsVersion,
             String jenkinsWar,
             List<Plugin> plugins,
+            List<String> excludePlugins,
             URL jenkinsUc,
             URL jenkinsUcExperimental,
             URL jenkinsIncrementalsRepoMirror,
@@ -94,6 +96,7 @@ public class Config {
         this.jenkinsVersion = jenkinsVersion;
         this.jenkinsWar = jenkinsWar;
         this.plugins = plugins;
+        this.excludePlugins = excludePlugins;
         this.jenkinsUc = jenkinsUc;
         this.jenkinsUcExperimental = jenkinsUcExperimental;
         this.jenkinsIncrementalsRepoMirror = jenkinsIncrementalsRepoMirror;
@@ -150,6 +153,10 @@ public class Config {
 
     public List<Plugin> getPlugins() {
         return plugins;
+    }
+
+    public List<String> getExcludePlugins() {
+        return excludePlugins;
     }
 
     public URL getJenkinsUc() {
@@ -234,6 +241,7 @@ public class Config {
         private VersionNumber jenkinsVersion;
         private String jenkinsWar;
         private List<Plugin> plugins = new ArrayList<>();
+        private List<String> excludePlugins = Collections.emptyList();
         private URL jenkinsUc = Settings.DEFAULT_UPDATE_CENTER;
         private URL jenkinsUcExperimental = Settings.DEFAULT_EXPERIMENTAL_UPDATE_CENTER;
         private URL jenkinsIncrementalsRepoMirror = Settings.DEFAULT_INCREMENTALS_REPO_MIRROR;
@@ -304,6 +312,15 @@ public class Config {
 
         public Builder withPlugins(List<Plugin> plugins) {
             this.plugins = plugins;
+            return this;
+        }
+
+        public Builder withExcludePlugins(List<String> excludePlugins) {
+            if (excludePlugins == null) {
+                this.excludePlugins = Collections.emptyList();
+                return this;
+            }
+            this.excludePlugins = excludePlugins;
             return this;
         }
 
@@ -395,6 +412,7 @@ public class Config {
                     jenkinsVersion,
                     jenkinsWar,
                     plugins,
+                    excludePlugins,
                     jenkinsUc,
                     jenkinsUcExperimental,
                     jenkinsIncrementalsRepoMirror,

--- a/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
+++ b/plugin-management-library/src/main/java/io/jenkins/tools/pluginmanager/impl/PluginManager.java
@@ -115,6 +115,7 @@ public class PluginManager implements Closeable {
     private final boolean useLatestAll;
     private final String userAgentInformation;
     private final boolean skipFailedPlugins;
+    private final Set<String> excludePlugins;
     private CloseableHttpClient httpClient;
     private final CacheManager cm;
     private final LogOutput logOutput;
@@ -140,6 +141,7 @@ public class PluginManager implements Closeable {
         useLatestSpecified = cfg.isUseLatestSpecified();
         useLatestAll = cfg.isUseLatestAll();
         skipFailedPlugins = cfg.isSkipFailedPlugins();
+        excludePlugins = new HashSet<>(cfg.getExcludePlugins());
         hashFunction = cfg.getHashFunction();
         httpClient = null;
         userAgentInformation = this.getUserAgentInformation();
@@ -231,6 +233,7 @@ public class PluginManager implements Closeable {
         List<Exception> exceptions = new ArrayList<>();
         allPluginsAndDependencies = findPluginsAndDependencies(cfg.getPlugins(), exceptions);
         pluginsToBeDownloaded = findPluginsToDownload(allPluginsAndDependencies);
+        pluginsToBeDownloaded = filterExcludedPlugins(pluginsToBeDownloaded);
         effectivePlugins = findEffectivePlugins(pluginsToBeDownloaded);
 
         listPlugins();
@@ -301,6 +304,37 @@ public class PluginManager implements Closeable {
             }
         }
         return pluginsToDownload;
+    }
+
+    /**
+     * Removes plugins on the exclusion list from the download set. A plugin in the exclusion list is dropped even when
+     * another plugin transitively depends on it; in that case a warning is logged because Jenkins may fail to load the
+     * dependent plugin.
+     *
+     * @param pluginsToDownload plugins resolved for download
+     * @return the filtered list without excluded plugins
+     */
+    public List<Plugin> filterExcludedPlugins(List<Plugin> pluginsToDownload) {
+        if (excludePlugins.isEmpty()) {
+            return pluginsToDownload;
+        }
+        Set<String> topLevelRequested = cfg.getPlugins().stream()
+                .map(Plugin::getName)
+                .collect(Collectors.toSet());
+        List<Plugin> filtered = new ArrayList<>(pluginsToDownload.size());
+        for (Plugin plugin : pluginsToDownload) {
+            if (excludePlugins.contains(plugin.getName())) {
+                if (topLevelRequested.contains(plugin.getName())) {
+                    logMessage("Excluding plugin " + plugin.getName() + " (explicitly requested but on exclude list)");
+                } else {
+                    logMessage("Excluding plugin " + plugin.getName() +
+                            " (transitive dependency; dependent plugins may fail to load)");
+                }
+            } else {
+                filtered.add(plugin);
+            }
+        }
+        return filtered;
     }
 
     /**
@@ -1719,6 +1753,10 @@ public class PluginManager implements Closeable {
      */
     public void setPluginsToBeDownloaded(List<Plugin> pluginsToBeDownloaded) {
         this.pluginsToBeDownloaded = pluginsToBeDownloaded;
+    }
+
+    public List<Plugin> getPluginsToBeDownloaded() {
+        return pluginsToBeDownloaded;
     }
 
     /**

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerIntegrationTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerIntegrationTest.java
@@ -382,6 +382,45 @@ class PluginManagerIntegrationTest {
     }
 
     @Test
+    void excludePluginsRemovesTransitiveDependency() throws IOException {
+        Plugin plugin1 = new Plugin("plugin1", "1.0", null, null);
+        Plugin plugin1Dependency = new Plugin("plugin1Dependency", "1.0.1", null, null).withoutDependencies();
+        plugin1.setDependencies(Collections.singletonList(plugin1Dependency));
+
+        List<Plugin> requestedPlugins = Collections.singletonList(plugin1);
+
+        PluginManager pluginManager = initPluginManager(
+                configBuilder -> configBuilder
+                        .withPlugins(requestedPlugins)
+                        .withExcludePlugins(Collections.singletonList("plugin1Dependency")));
+
+        pluginManager.start();
+
+        assertThat(pluginManager.getPluginsToBeDownloaded())
+                .extracting(Plugin::getName)
+                .containsExactly("plugin1");
+    }
+
+    @Test
+    void excludePluginsRemovesTopLevelRequestedPlugin() throws IOException {
+        Plugin keep = new Plugin("plugin1", "1.0", null, null).withoutDependencies();
+        Plugin drop = new Plugin("plugin2", "2.0", null, null).withoutDependencies();
+
+        List<Plugin> requestedPlugins = Arrays.asList(keep, drop);
+
+        PluginManager pluginManager = initPluginManager(
+                configBuilder -> configBuilder
+                        .withPlugins(requestedPlugins)
+                        .withExcludePlugins(Collections.singletonList("plugin2")));
+
+        pluginManager.start();
+
+        assertThat(pluginManager.getPluginsToBeDownloaded())
+                .extracting(Plugin::getName)
+                .containsExactly("plugin1");
+    }
+
+    @Test
     void verifyBackups() throws Exception {
         // First cycle, empty dir
         Plugin initialTrileadAPI = new Plugin("trilead-api", "1.0.12", null, null);

--- a/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
+++ b/plugin-management-library/src/test/java/io/jenkins/tools/pluginmanager/impl/PluginManagerTest.java
@@ -871,6 +871,30 @@ class PluginManagerTest {
     }
 
     @Test
+    void filterExcludedPluginsTest() {
+        Plugin git = new Plugin("git", "1.0.0", null, null);
+        Plugin credentials = new Plugin("credentials", "2.1.14", null, null);
+        Plugin structs = new Plugin("structs", "1.18", null, null);
+
+        // no exclude list configured → list returned unchanged
+        List<Plugin> noExclude = pm.filterExcludedPlugins(Arrays.asList(git, credentials, structs));
+        assertThat(noExclude).containsExactly(git, credentials, structs);
+
+        // exclude "credentials" (top-level) and "structs" (transitive)
+        Config excludeCfg = Config.builder()
+                .withJenkinsWar(Settings.DEFAULT_WAR)
+                .withPluginDir(new File(folder, "plugins-exclude"))
+                .withCachePath(newFolder(folder, "junit-exclude").toPath())
+                .withPlugins(Arrays.asList(git, credentials))
+                .withExcludePlugins(Arrays.asList("credentials", "structs"))
+                .build();
+        PluginManager excludePm = new PluginManager(excludeCfg);
+
+        List<Plugin> filtered = excludePm.filterExcludedPlugins(Arrays.asList(git, credentials, structs));
+        assertThat(filtered).containsExactly(git);
+    }
+
+    @Test
     void findPluginsToDownloadTest() {
         Map<String, Plugin> requestedPlugins = new HashMap<>();
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
We work with Casc and we manage our Jenkins state with Salt. Occasionally, when a plugin is updated, causing the state to crash. It can also happen that configurations used in our standard building blocks change 'suddenly'. In such cases, we are sometimes unable to implement changes quickly enough, which is why we want to be able to exclude plugins. Currently, we do this by manipulating the list ourselves before running de plugin installation manager tool, but it would be better if I could provide this list.

### Testing done

Built the jar.
                                                                                                                                                                             
Test 1: transitive dependency exclude:
`--plugins matrix-auth:3.2.2 --exclude-plugins ionicons-api commons-lang3-api`
Without exclude, plugins that will be downloaded lists matrix-auth + ionicons-api + commons-lang3-api. With exclude, only matrix-auth 3.2.2 remains, and the log shows:
```
Excluding plugin ionicons-api (transitive dependency; dependent plugins may fail to load)
Excluding plugin commons-lang3-api (transitive dependency; dependent plugins may fail to load)
```

Test 2: top-level requested exclude:
`--plugins git:5.4.0 mailer:472.vf7c289a_4b_420 --exclude-plugins mailer`
Without exclude, mailer appears once in the download list. With exclude, mailer appears 0 times. The log shows:
```
Excluding plugin mailer (explicitly requested but on exclude list)
```

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests that demonstrate the feature works or the issue is fixed